### PR TITLE
Update Swisstopo validation scripts: correctness fix, curl transport, bilingual UI

### DIFF
--- a/COMMUNITY SCRIPTS/Swisstopo systematic validation/README.md
+++ b/COMMUNITY SCRIPTS/Swisstopo systematic validation/README.md
@@ -1,99 +1,69 @@
 # Swisstopo Systematic Point Cloud Validation
 
-**Professional point cloud validation tool for Cyclone 3DR** - Validates measured heights against official Swiss topographic reference data.
-Created by Bimatic, Jan Sigrist - for any Questions and Feedback contact me at jan.sigrist@bimatic.ch
+**Grid-based point cloud validation for Cyclone 3DR** - checks a whole point cloud against official swisstopo reference heights instead of sampling single points.
 
-## 🎯 Overview
+| Script info |  |
+| -------- | ------- |
+| Contact | Jan Sigrist, Bimatic GmbH |
+| Email | jan.sigrist@bimatic.ch |
 
-This script performs systematic grid-based validation of point cloud heights against official Swisstopo reference data. It's designed for professional surveying workflows requiring accuracy verification against national geodetic standards.
+## Description
 
-## ✨ Key Features
+Walks a regular grid across a point cloud's footprint and checks the local height against the official swisstopo height API at every cell. Designed for validating a scan or model systematically rather than spot-checking it, with color-coded labels, a classification summary and an optional CSV report.
 
-- **Systematic Grid Validation**: Automated grid-based sampling across entire point cloud bounding box
-- **Official Swisstopo Integration**: Direct API connection to `api3.geo.admin.ch` for reference heights
-- **Intelligent Ground Detection**: Advanced cylinder-based point extraction with median approximation
-- **Professional Labeling**: Comprehensive 5-row labels with tolerance visualization and organized grouping
-- **Detailed CSV Reports**: Statistical analysis with configurable export options including fallback mechanisms
-- **Robust Error Handling**: Multiple fallback strategies ensure reliable operation
+**Deutsch:** Systematische Rastervalidierung einer Punktwolke gegen offizielle Swisstopo-Referenzhöhen, statt einzelner Stichproben. Farbcodierte Labels, Klassifikationsübersicht und optionaler CSV-Bericht.
 
-## 🛠️ Requirements
+### What's new (2026-09-01)
 
-- **Cyclone 3DR 2025.1.4** or newer
-- **Windows environment** with curl command available
-- **Internet connection** for Swisstopo API access
-- **LV95 coordinate system** (EPSG:2056) point clouds
+- **Correctness fix - the false "no data" result**: the previous version centred its point-cloud search cylinder on the value it got back from the swisstopo API, before it knew the cloud's actual height. A real elevation defect larger than roughly the cylinder's half-height (2.5 m) made the cylinder miss the point-cloud data entirely, so the cell was reported as `NO_DATA` instead of `FAILED`. The cloud's local height is now measured first, with a search cylinder spanning the full vertical extent of the data at that cell, closing that blind spot completely.
+- **Cloud before network**: measuring the point cloud now happens before any API call, so grid cells with no cloud coverage generate zero network traffic.
+- **Batched reference lookups**: reference heights are resolved in batches of up to 40 points through a single curl process (`--parallel`, 8 concurrent transfers, 30 s per-transfer timeout) instead of one process per point. Measured: 99 grid points resolved in about 1.5 seconds with zero failed lookups.
+- **Automatic retry**: after the batched pass, a single-request retry pass mops up anything that is still missing.
+- **Actionable diagnostics**: if `API_FAILED` rows remain, the summary reports how many were transfer errors versus bad responses, plus the last error text, instead of a bare failure count.
+- **Coordinate guardrail**: the point cloud's LV95 position is validated before the run starts.
+- **Bilingual dialogs**: field names, tooltips and the summary dialog are English / German.
+- **Reliable transport**: all requests go through curl instead of the engine's `fetch()` API, which intermittently fails inside the GUI process with an SSL certificate-chain error when calling `api3.geo.admin.ch`.
+- **Readable failures**: every error names the step it happened in, and the message is never blank.
 
-## 📋 Usage Instructions
+## Tested version
 
-### 1. Preparation
-- Import your point cloud(s) into Cyclone 3DR
-- Ensure coordinate system is **LV95 (EPSG:2056)**
-- Select the point cloud(s) you want to validate
+- Cyclone 3DR 2026.1.2.50530 (headless and interactive)
+- Should run on Cyclone 3DR 2025.1 or newer (no dependency on the 2026.1.2 `fetch()` runtime)
 
-### 2. Script Execution
-1. Run the script from Cyclone 3DR Scripts menu
-2. Configure parameters in the dialog:
-   - **Grid Spacing**: Distance between validation points (default: 20m)
-   - **Search Radius**: Cylinder radius for point extraction (default: 1m)
-   - **Error Threshold**: Maximum allowed deviation (default: 1m)
-   - **Create All Labels**: Generate labels for all points or errors only
-   - **Generate Report**: Enable detailed CSV export with multiple save options
+## Licensing
 
-### 3. Results
-The script produces:
-- **Validation Labels**: Color-coded 5-row labels showing complete validation data
-- **Statistical Summary**: Console output with validation counts
-- **CSV Report**: Detailed analysis file with fallback save mechanisms
-- **Organized Groups**: Labels sorted by classification (OK/ERROR/NO_DATA/API_FAILED)
+Free to use and adapt, no warranty. Compatible with any Cyclone 3DR edition (Standard, Survey, Advanced).
 
-## 📊 Output Classifications
+## Usage
 
-| Classification | Description | Color Coding |
-|---------------|-------------|--------------|
-| **OK** | Deviation within threshold | Green/Normal |
-| **ERROR** | Deviation exceeds threshold | Red/Warning |
-| **NO_DATA** | No point cloud data found | Yellow/Info |
-| **API_FAILED** | Swisstopo API unavailable | Gray/Error |
+1. Import and select the point cloud(s) to validate. Coordinate system must be **LV95 (EPSG:2056)**.
+2. Run the script and configure:
+   - **Grid spacing**: distance between validation points (default 20 m)
+   - **Search radius**: point-cloud search cylinder radius (default 1 m)
+   - **Tolerance**: maximum allowed deviation (default 1 m)
+   - **Create labels for every point**: off = only points over tolerance get a label
+   - **Create a CSV report**: exports a detailed CSV alongside the labels
+3. Review the classification labels and the CSV report.
 
-## 🔧 Technical Details
+## Output classification
 
-### Algorithm Components
+| Classification | Meaning |
+|---|---|
+| `OK` | Deviation within tolerance |
+| `FAILED` | Deviation exceeds tolerance |
+| `NO_DATA` | No point-cloud data found at this grid cell |
+| `API_FAILED` | swisstopo reference height could not be retrieved |
 
-1. **Grid Generation**: Creates systematic validation points across bounding box
-2. **Reference Height Query**: Retrieves official heights via Swisstopo REST API
-3. **Point Cloud Sampling**: Uses centered cylinders for robust ground detection
-4. **Height Calculation**: Weighted average with median approximation of lower 25% points for accuracy
-5. **Comparison & Classification**: Configurable tolerance-based validation
-6. **Documentation**: Professional 5-row labels and comprehensive reporting
+## Algorithm
 
-### API Integration
-```javascript
-// Swisstopo Height API
-https://api3.geo.admin.ch/rest/services/height?easting={E}&northing={N}&sr=2056&format=json
-```
+1. **Grid generation**: systematic points across the point cloud's bounding box.
+2. **Point cloud sampling**: a search cylinder spanning the full local vertical extent of the data (see "What's new" above) extracts the nearby points.
+3. **Ground height**: bounding-box midpoint for near-flat patches, lowest 15% slice for the rest.
+4. **Reference height query**: batched curl requests against the swisstopo height API (see "What's new").
+5. **Comparison and classification**: configurable tolerance-based validation.
+6. **Documentation**: 3-column labels (Measure / Reference / Deviation), classification groups, red marker spheres on `FAILED` points, CSV export.
 
-### Ground Detection Method
-- **Primary Method**: Median approximation using iterative cylinder approach for lower 25% of points
-- **Fallback Method**: Simple average for small height variations
-- **Search Strategy**: Fixed 5m vertical search height centered around reference elevation
-- **Weighting**: Results weighted by point count when multiple clouds contribute
-
-## 📄 Label Information
-
-Each validation label contains 5 rows with comprehensive data:
-- **Row 0**: Measured height from point cloud (Code 1)
-- **Row 1**: Swisstopo reference height (Code 2)
-- **Row 2**: Height difference/deviation (Code 3) - **Primary measurement**
-- **Row 3**: Point ID for traceability (Code 4)
-- **Row 4**: Grid coordinates - Easting, Northing (Codes 5)
-
-### Label Features
-- **Enhanced Comments**: Include classification and deviation in label name
-- **Dynamic Tolerances**: ERROR points use stricter tolerance, OK points use warning threshold
-- **Group Organization**: Automatic sorting into classification-based groups
-- **Fallback System**: Robust 3-row basic labels if enhanced labels fail
-
-## 📈 CSV Report Format
+## CSV report format
 
 | Column | Description | Unit |
 |--------|-------------|------|
@@ -106,78 +76,44 @@ Each validation label contains 5 rows with comprehensive data:
 | Classification | Validation result | - |
 | Grid_Spacing_m | Grid parameter | m |
 | Search_Radius_m | Search parameter | m |
-| Error_Threshold_m | Tolerance parameter | m |
+| Tolerance_m | Tolerance parameter | m |
 
-### CSV Export Options
-1. **User Dialog**: Standard save dialog for user-selected location
-2. **Temp Directory**: Automatic fallback with timestamp
-3. **Console Output**: Last resort for manual copy-paste
+## Requirements
 
-## ⚙️ Configuration Parameters
+- **Leica Cyclone 3DR 2025.1** or newer
+- **curl** command-line tool (built into Windows 10/11, must be on PATH)
+- Internet connection to `api3.geo.admin.ch`
+- Point cloud(s) georeferenced in **LV95 (EPSG:2056)**
 
-### Grid Spacing (2-100m)
-- **Small values (2-10m)**: Detailed analysis, more processing time
-- **Medium values (15-25m)**: Balanced approach (recommended)
-- **Large values (50-100m)**: Overview analysis, faster processing
+## Configuration guidance
 
-### Search Radius (0.05-5m)
-- **Small radius (0.1-0.5m)**: Precise point sampling (recommended for high-quality data)
-- **Medium radius (1-2m)**: Standard terrain analysis
-- **Large radius (3-5m)**: Rough terrain or sparse data
+**Grid spacing**: small (2-10 m) for detailed analysis; medium (15-25 m) for a balanced default; large (50-100 m) for a fast overview.
 
-### Error Threshold (0.02-10m)
-- **Strict (0.02-0.5m)**: High precision surveys (recommended for quality control)
-- **Standard (0.5-2m)**: General validation
-- **Lenient (5-10m)**: Rough terrain assessment
+**Search radius**: small (0.1-0.5 m) for precise, high-density data; medium (1-2 m) for standard terrain; large (3-5 m) for rough or sparse data.
 
-## 🚨 Troubleshooting
+**Tolerance**: strict (0.02-0.5 m) for quality control on high-precision surveys; standard (0.5-2 m) for general validation; lenient (5-10 m) for rough terrain assessment.
 
-### Common Issues
+## Troubleshooting
 
-**"No point cloud selected"**
-- Ensure at least one SCloud object is selected before running
+| Problem | Solution |
+|---------|----------|
+| "Please select at least one point cloud" | Select at least one SCloud before running |
+| Many `API_FAILED` rows | Check the summary dialog's API diagnosis (transfer vs. response errors); check internet connection / firewall / proxy |
+| Many `NO_DATA` rows | Increase the search radius, or confirm the cloud actually covers the grid area |
+| Slow run | Increase grid spacing, or reduce the validated area |
 
-**"API request failed"**
-- Check internet connection
-- Verify coordinates are within Switzerland
-- Try again later (API may be temporarily unavailable)
+## Files
 
-**"No cloud data found"**
-- Increase search radius
-- Check if point cloud covers the validation area
-- Verify coordinate system alignment
+- Main script: [Swisstopo Systematic Validation.js](./Swisstopo%20Systematic%20Validation.js)
 
-**"Label creation failed"**
-- Script automatically falls back to basic 3-row labels
-- Check console for specific error messages
+## Version history
 
-**Performance issues**
-- Reduce grid density (increase spacing)
-- Limit validation area
-- Close other resource-intensive applications
+- **2026-09-01**: Search-cylinder correctness fix, cloud-before-network ordering, batched curl transport, automatic retry, API diagnostics, LV95 guardrail, bilingual dialogs, readable error handling
+- **1.0** (2025-08-25): initial release
 
-### Best Practices
+## License and attribution
 
-1. **Start with larger grid spacing** for overview analysis
-2. **Use appropriate search radius** based on point cloud density
-3. **Validate coordinate system** before processing
-4. **Check sample results** before full validation
-5. **Save reports** for documentation and analysis
-6. **Monitor console output** for detailed processing information
-
-## 📋 Version & Compatibility
-
-- **Script Version**: 1.0 (2025-08-25)
-- **Cyclone 3DR**: 2025.1.4 or newer required
-- **Author**: Jan Sigrist (Bimatic GmbH) - www.bimatic.ch
-- **Platform**: Windows with curl support
-
-## 📋 License & Attribution
-
-- **Script**: Developed for professional surveying workflows
-- **Data Source**: © swisstopo - Swiss Federal Office of Topography
-- **API**: Height data from `api3.geo.admin.ch`
-- **Coordinate System**: LV95 (EPSG:2056)
-- **Platform**: Leica Cyclone 3DR
-
----
+- Data source: (c) swisstopo - Swiss Federal Office of Topography
+- API: height data from `api3.geo.admin.ch`
+- Coordinate system: LV95 (EPSG:2056)
+- Platform: Leica Cyclone 3DR

--- a/COMMUNITY SCRIPTS/Swisstopo systematic validation/Swisstopo Systematic Validation.js
+++ b/COMMUNITY SCRIPTS/Swisstopo systematic validation/Swisstopo Systematic Validation.js
@@ -1,590 +1,618 @@
-/// <reference path="C:/Program Files/Leica Geosystems/Cyclone 3DR/Script/JsDoc/Reshaper.d.ts"/>
+/// <reference path="C:/Program Files/Leica Geosystems/Cyclone 3DR/Script/JsDoc/Reshaper.d.ts" />
+// @ts-check
 
-// -----------------------------------------------------------------------------
-//  SwisstopoSystematicValidation.js – v1.0 (2025-08-25)
-// -----------------------------------------------------------------------------
-//  ENGLISH: Systematic point cloud validation against Swisstopo reference data
-//  DEUTSCH: Systematische Punktwolken-Validierung gegen Swisstopo-Referenzdaten
-//  Author: Jan Sigrist (Bimatic GmbH) - www.bimatic.ch
+/**
+ * Script: Swisstopo Systematic Validation
+ * Purpose: Systematic grid validation of a point cloud against the official
+ *          swisstopo height API. The cloud height is measured FIRST, so grid
+ *          cells without cloud data cause no API traffic, and gross height
+ *          errors are reported as FAILED instead of NO_DATA (the previous
+ *          design centred its search cylinder on the API height before
+ *          knowing the cloud's real height, which made large defects miss
+ *          the cylinder entirely). All heights of a batch are fetched with a
+ *          SINGLE curl process (--parallel, one reused TLS connection),
+ *          which keeps large grids fast.
+ * Note:    Web requests go through curl instead of the engine's fetch(). fetch()
+ *          intermittently fails inside the GUI process with an SSL
+ *          certificate-chain error ("Zertifikat des Ausstellers ... konnte
+ *          nicht gefunden werden"); curl as a separate process does not hit it.
+ * Author: Jan Sigrist (Bimatic GmbH)
+ * Contact: jan.sigrist@bimatic.ch
+ * Date: 2026-09-01
+ * Tested with: Cyclone 3DR 2026.1.2
+ * Requires: Cyclone 3DR 2025.1+, internet access, curl (built into Windows 10/11)
+ * Licensing: free to use and adapt, no warranty. Compatible with any Cyclone 3DR edition.
+ * Data source: api3.geo.admin.ch (LV95 / EPSG:2056), (c) swisstopo
+ */
 
-//  FEATURES:
-//  - Systematic grid-based validation across entire point cloud bounding box
-//  - Official Swisstopo height API integration (api3.geo.admin.ch)
-//  - Intelligent cylinder-based point extraction with ground detection
-//  - Professional labels with tolerance visualization and organized grouping
-//  - Comprehensive CSV reporting with statistical analysis
-//  - Robust error handling with multiple fallback strategies
-//
-//  WORKFLOW:
-//  1. Generate systematic validation grid over point cloud bounding box
-//  2. Query Swisstopo API for official reference heights (EPSG:2056)
-//  3. Extract representative ground heights from pointcloud
-//  4. Compare measured vs. reference heights with configurable tolerance
-//  5. Create labels with deviation analysis
-//  6. Export detailed CSV report for further analysis
-// -----------------------------------------------------------------------------
+// ==================== Constants ====================
 
-// -------------------- CONFIGURATION DIALOG -----------
-var dlg = SDialog.New("Point Cloud Validation");
-dlg.AddText("Systematic validation of point cloud heights against Swisstopo reference data", SDialog.EMessageSeverity.Instruction);
+var SCRIPT_TITLE = "Swisstopo Systematic Validation / Rastervalidierung";
+var LOGO_PATH = CurrentScriptPath() + "/../Bimatic_white_just_Name.svg";
+var HEIGHT_DECIMALS = 3;
+var MIN_LOCAL_POINTS = 5;
+var API_BATCH_SIZE = 40;        // URLs per curl call (one process, one TLS connection)
+var CURL_PARALLEL_MAX = 8;      // parallel transfers inside one curl call (fair use)
+var CURL_TIMEOUT_S = 30;        // per-transfer timeout [s]
+var LOGGED_FAILURE_LIMIT = 3;   // log details for the first N failed requests only
 
-dlg.AddLength({
-    id: "gridSpacing",
-    name: "Grid spacing [m]",
-    value: 20.0,
-    min: 2.0,
-    max: 100.0,
-    saveValue: true,
-    tooltip: "Distance between validation points in the grid"
-});
+var CLASS_OK = "OK";
+var CLASS_ERROR = "FAILED";
+var CLASS_NO_DATA = "NO_DATA";
+var CLASS_API_FAILED = "API_FAILED";
 
-dlg.AddLength({
-    id: "searchRadius",
-    name: "Search radius [m]",
-    value: 1.0,
-    min: 0.05,
-    max: 5.0,
-    saveValue: true,
-    tooltip: "Radius for pointcloud search at each grid point"
-});
+var FAIL_COLOR = [0.9, 0.1, 0.1];
 
-dlg.AddLength({
-    id: "tolerance",
-    name: "Error threshold [m]",
-    value: 1.0,
-    min: 0.02,
-    max: 10.0,
-    saveValue: true,
-    tooltip: "Maximum allowed deviation for classification as OK"
-});
+// LV95 plausibility bounds (Switzerland)
+var LV95_MIN_E = 2450000, LV95_MAX_E = 2850000;
+var LV95_MIN_N = 1050000, LV95_MAX_N = 1310000;
 
+// ==================== Main Function ====================
 
-dlg.AddBoolean({
-    id: "createAllLabels",
-    name: "Create labels for all points",
-    value: true,
-    saveValue: true,
-    tooltip: "Create labels for all validation points, not just errors"
-});
+function main() {
+    try {
+        var params = getUserParameters();
+        var clouds = getSelectedClouds();
+        validateLv95Position(clouds);
+        configureLabelStyle();
 
-dlg.AddBoolean({
-    id: "generateReport",
-    name: "Generate detailed report",
-    value: true,
-    saveValue: true,
-    tooltip: "Generate and save detailed validation report"
-});
+        var results = validateGrid(clouds, params);
+        var summary = summarize(results);
 
-var config = dlg.Run();
-if (config.ErrorCode !== 0) {
-    throw new Error("Operation cancelled by user");
+        createLabels(results, params);
+        if (params.generateReport) {
+            exportCsvReport(results, params);
+        }
+        showSummary(summary, params);
+    } catch (error) {
+        handleError(error);
+    }
 }
 
-var GRID_SPACING = config.gridSpacing;
-var SEARCH_RADIUS = config.searchRadius;
-var ERROR_THRESHOLD = config.tolerance;
-var WARNING_THRESHOLD = ERROR_THRESHOLD * 0.5; // Warning at 50% of error threshold
-var CREATE_ALL_LABELS = config.createAllLabels;
-var GENERATE_REPORT = config.generateReport;
+// ==================== User Input ====================
 
-// -------------------- POINT CLOUD SELECTION -----------
-var selectedClouds = SCloud.FromSel();
-if (selectedClouds.length === 0) {
-    SDialog.Message("Please select at least one point cloud", SDialog.EMessageSeverity.Error, "Selection Error");
-    throw new Error("No point cloud selected");
+function getUserParameters() {
+    var dialog = SDialog.New(SCRIPT_TITLE);
+    dialog.SetHeader(SCRIPT_TITLE, LOGO_PATH, 60);
+    dialog.AddText(
+        "EN: Systematic height check of the point cloud against swisstopo reference data.",
+        SDialog.EMessageSeverity.Instruction
+    );
+    dialog.AddText(
+        "DE: Systematische Höhenprüfung der Punktwolke gegen Swisstopo-Referenzdaten.",
+        SDialog.EMessageSeverity.Instruction
+    );
+
+    dialog.AddLength({
+        id: "gridSpacing", name: "Grid spacing / Rasterabstand [m]",
+        value: 20.0, min: 2.0, max: 100.0, saveValue: true,
+        tooltip: "EN: Distance between validation points | DE: Abstand zwischen den Validierungspunkten"
+    });
+    dialog.AddLength({
+        id: "searchRadius", name: "Search radius / Suchradius [m]",
+        value: 1.0, min: 0.05, max: 5.0, saveValue: true,
+        tooltip: "EN: Radius of the point-cloud search per grid point | DE: Radius der Punktwolkensuche je Rasterpunkt"
+    });
+    dialog.AddLength({
+        id: "tolerance", name: "Tolerance / Toleranz [m]",
+        value: 1.0, min: 0.02, max: 10.0, saveValue: true,
+        tooltip: "EN: Deviations above this value are classified FAILED | DE: Abweichungen darüber werden als FEHLER klassiert"
+    });
+    dialog.AddBoolean({
+        id: "createAllLabels", name: "Create labels for every point / Labels für alle Punkte erstellen",
+        value: true, saveValue: true,
+        tooltip: "EN: Off = only points over tolerance get a label | DE: Aus = nur Punkte über der Toleranz erhalten ein Label"
+    });
+    dialog.AddBoolean({
+        id: "generateReport", name: "Create a CSV report / CSV-Bericht erstellen",
+        value: true, saveValue: true
+    });
+
+    // Run() is typed as {ErrorCode} only; the field ids are dynamic
+    var result = /** @type {any} */ (dialog.Run());
+    if (result.ErrorCode !== 0) {
+        throw new Error("EN: Cancelled by user. | DE: Vom Benutzer abgebrochen.");
+    }
+
+    return {
+        gridSpacing: result.gridSpacing,
+        searchRadius: result.searchRadius,
+        tolerance: result.tolerance,
+        createAllLabels: result.createAllLabels,
+        generateReport: result.generateReport
+    };
 }
 
-print("=== Swisstopo Point Cloud Validation Started ===");
-print("Grid spacing: " + GRID_SPACING + "m, Search radius: " + SEARCH_RADIUS + "m, Error threshold: " + ERROR_THRESHOLD + "m");
-print("Selected " + selectedClouds.length + " point cloud(s)");
+function getSelectedClouds() {
+    var clouds = SCloud.FromSel();
+    if (clouds.length === 0) {
+        throw new Error(
+            "EN: Please select at least one point cloud. | " +
+            "DE: Bitte mindestens eine Punktwolke auswählen."
+        );
+    }
+    return clouds;
+}
 
-// -------------------- HELPER FUNCTIONS --------------------
+function validateLv95Position(clouds) {
+    var bounds = computeBoundingBox(clouds);
+    var insideLv95 =
+        bounds.minX >= LV95_MIN_E && bounds.maxX <= LV95_MAX_E &&
+        bounds.minY >= LV95_MIN_N && bounds.maxY <= LV95_MAX_N;
 
-function getSwisstopoHeight(easting, northing) {
-    var apiUrl = "https://api3.geo.admin.ch/rest/services/height" +
+    if (!insideLv95) {
+        throw new Error(
+            "EN: The point cloud lies outside the LV95 bounds of Switzerland. The\n" +
+            "project must be georeferenced in LV95 / EPSG:2056.\n\n" +
+            "DE: Die Punktwolke liegt ausserhalb der LV95-Grenzen der Schweiz.\n" +
+            "Das Projekt muss in LV95 / EPSG:2056 georeferenziert sein."
+        );
+    }
+}
+
+// ==================== Label Styling ====================
+
+/**
+ * Configure the global SLabel appearance once. SLabel color setters are static
+ * (global), so per-label coloring is impossible. Status is conveyed by the
+ * comment verdict, the OK / FAILED group and a red sphere marker.
+ */
+function configureLabelStyle() {
+    SLabel.SetDecimalNumber(HEIGHT_DECIMALS);
+    SLabel.SetSizeType(SLabel.LONG);
+    SLabel.SetBackgroundType(SLabel.SPECIAL_COLOR);
+    SLabel.SetBackgroundColor(0.13, 0.13, 0.13, 0.0);
+    SLabel.SetLineColor(0.95, 0.95, 0.95);
+}
+
+function createLabels(results, params) {
+    for (var i = 0; i < results.length; i++) {
+        var result = results[i];
+        var hasHeights = result.measuredHeight !== null && result.swisstopoHeight !== null;
+        if (!hasHeights) {
+            continue;
+        }
+        if (params.createAllLabels || result.classification === CLASS_ERROR) {
+            createDeviationLabel(result, params.tolerance, result.classification, params.searchRadius);
+        }
+    }
+}
+
+/**
+ * Create a self-explaining height label (columns Measure | Reference | Deviation).
+ */
+function createDeviationLabel(result, tolerance, classification, markerRadius) {
+    var point = SPoint.New(result.easting, result.northing, result.measuredHeight);
+    var statusGroup = "Swisstopo Validation/" + classification;
+
+    var label = SLabel.New(1, 3);
+    label.SetColType([SLabel.Measure, SLabel.Reference, SLabel.Deviation]);
+    label.SetLineType([SLabel.Level]);
+
+    label.SetCell(0, 0, parseFloat(result.measuredHeight.toFixed(HEIGHT_DECIMALS)));
+    label.SetCell(0, 1, parseFloat(result.swisstopoHeight.toFixed(HEIGHT_DECIMALS)));
+    label.SetCell(0, 2, parseFloat(result.heightDiff.toFixed(HEIGHT_DECIMALS)));
+
+    label.SetComment(buildVerdict(result.heightDiff, tolerance, result.pointIndex));
+    label.ShowComment(true);
+
+    label.AttachToPoint(point);
+    label.AddToDoc();
+    label.MoveToGroup(statusGroup, true);
+
+    if (classification === CLASS_ERROR) {
+        createFailMarker(point, statusGroup, markerRadius);
+    }
+}
+
+/**
+ * Red sphere marking an out-of-tolerance grid point (per-label coloring is
+ * impossible, SComp.SetColors on geometry is the reliable per-point flag).
+ */
+function createFailMarker(point, group, radius) {
+    var sphere = SSphere.New(point, radius);
+    sphere.SetColors(FAIL_COLOR[0], FAIL_COLOR[1], FAIL_COLOR[2]);
+    sphere.SetName("FAILED");
+    sphere.AddToDoc();
+    sphere.MoveToGroup(group, false);
+}
+
+function buildVerdict(deviation, tolerance, pointIndex) {
+    var signed = (deviation >= 0 ? "+" : "") + deviation.toFixed(HEIGHT_DECIMALS) + " m";
+    if (Math.abs(deviation) > tolerance) {
+        return "P" + pointIndex + "  " + signed + " > tolerance " + tolerance.toFixed(2) + " m";
+    }
+    return "P" + pointIndex + "  OK  " + signed;
+}
+
+// ==================== Swisstopo API ====================
+
+/**
+ * Diagnostics for failed API requests, shown in the summary so a broken run
+ * explains itself (transfer error vs. bad response) instead of silently
+ * producing API_FAILED rows.
+ */
+var apiDiagnostics = { httpErrors: 0, exceptions: 0, logged: 0, lastDetail: "" };
+
+function recordApiFailure(detail, isException) {
+    if (isException) {
+        apiDiagnostics.exceptions++;
+    } else {
+        apiDiagnostics.httpErrors++;
+    }
+    apiDiagnostics.lastDetail = detail;
+    if (apiDiagnostics.logged < LOGGED_FAILURE_LIMIT) {
+        apiDiagnostics.logged++;
+        print("swisstopo request failed: " + detail);
+    }
+}
+
+function buildHeightUrl(easting, northing) {
+    return "https://api3.geo.admin.ch/rest/services/height" +
         "?easting=" + easting +
         "&northing=" + northing +
-        "&sr=2056" +
-        "&format=json";
-
-    var tempFileName = TempPath() + "swisstopo_simple_" +
-        Math.round(easting) + "_" + Math.round(northing) + ".json";
-
-    var curlResult = Execute("curl", ["-s", "-o", tempFileName, apiUrl]);
-    if (curlResult !== 0) {
-        return null;
-    }
-
-    var responseFile = SFile.New(tempFileName);
-    var responseText = null;
-
-    if (responseFile.Open(SFile.ReadOnly)) {
-        responseText = responseFile.ReadAll();
-        responseFile.Close();
-        responseFile.Remove();
-    }
-
-    if (!responseText) {
-        return null;
-    }
-
-    try {
-        var apiResponse = JSON.parse(responseText);
-        if (apiResponse.height !== undefined) {
-            var height = parseFloat(apiResponse.height);
-            return isNaN(height) ? null : height;
-        }
-    } catch (parseError) {
-        return null;
-    }
-
-    return null;
+        "&sr=2056&format=json";
 }
 
-function getCloudHeightAtPoint(clouds, centerX, centerY, centerZ, radius) {
-    var searchHeight = 5.0; // Fixed 5m search height
-    // Center the cylinder vertically around the reference height
-    var cylinderCenterZ = centerZ - searchHeight / 2.0;
-    var cylinderCenter = SPoint.New(centerX, centerY, cylinderCenterZ);
-    var cylinderAxis = SVector.New(0, 0, 1);
-    var cylinder = SCylinder.New(cylinderCenter, cylinderAxis, radius, searchHeight);
+var curlBatchCounter = 0;
 
-    var allHeights = [];
+/**
+ * Fetch the heights of one batch with a SINGLE curl process: one reused TLS
+ * connection, parallel transfers, no per-request process spawn. curl runs
+ * outside the engine, so the GUI fetch() SSL problem cannot occur. Individual
+ * failures leave their response file missing/invalid and become null (picked
+ * up later by the retry pass).
+ */
+function fetchHeightBatchViaCurl(batch) {
+    curlBatchCounter++;
+    var args = ["-sS", "-L", "--parallel", "--parallel-max", "" + CURL_PARALLEL_MAX,
+        "-m", "" + CURL_TIMEOUT_S];
+    var responseFiles = [];
 
-    for (var cloudIdx = 0; cloudIdx < clouds.length; cloudIdx++) {
-        try {
-            var cloud = clouds[cloudIdx];
-            var separateResult = cloud.SeparateFeature(cylinder, 0, SCloud.FILL_IN_ONLY);
-
-            if (separateResult.ErrorCode === 0 && separateResult.InCloud && separateResult.InCloud.GetNumber() > 5) {
-                var localCloud = separateResult.InCloud;
-                var bbox = localCloud.GetBoundingBox();
-                var minZ = bbox.LowPoint.GetZ();
-                var maxZ = bbox.UpPoint.GetZ();
-                var heightRange = maxZ - minZ;
-
-                // Try to get median of lower 25% using iterative cylinder approach
-                var groundHeight;
-                if (heightRange > 0.5) { // Only do complex calculation for significant height variation
-                    try {
-                        // Create a thin cylinder in the lower 25% of the height range
-                        var lowerQuartileHeight = minZ + heightRange * 0.25;
-                        var thinCylinderHeight = Math.max(0.1, heightRange * 0.15); // 15% of range or minimum 10cm
-
-                        var groundCylinderCenter = SPoint.New(centerX, centerY, minZ + thinCylinderHeight / 2);
-                        var groundCylinder = SCylinder.New(groundCylinderCenter, cylinderAxis, radius, thinCylinderHeight);
-
-                        var groundResult = localCloud.SeparateFeature(groundCylinder, 0, SCloud.FILL_IN_ONLY);
-
-                        if (groundResult.ErrorCode === 0 && groundResult.InCloud && groundResult.InCloud.GetNumber() > 3) {
-                            // Use the center of the ground points bounding box as median approximation
-                            var groundBbox = groundResult.InCloud.GetBoundingBox();
-                            var groundMinZ = groundBbox.LowPoint.GetZ();
-                            var groundMaxZ = groundBbox.UpPoint.GetZ();
-                            groundHeight = (groundMinZ + groundMaxZ) / 2; // Median approximation
-                        } else {
-                            // Fallback to lower quartile calculation
-                            groundHeight = minZ + heightRange * 0.25;
-                        }
-                    } catch (groundError) {
-                        // Fallback to simple calculation
-                        groundHeight = minZ + heightRange * 0.25;
-                    }
-                } else {
-                    // For small height variations, use simple average
-                    groundHeight = (minZ + maxZ) / 2;
-                }
-
-                allHeights.push({
-                    height: groundHeight,
-                    pointCount: localCloud.GetNumber()
-                });
-            }
-        } catch (error) {
-            // Skip this cloud on error
-        }
+    for (var i = 0; i < batch.length; i++) {
+        var responseFile = TempPath() + "swisstopo_h_" + curlBatchCounter + "_" + i + ".json";
+        responseFiles.push(responseFile);
+        args.push("-o", responseFile, buildHeightUrl(batch[i].easting, batch[i].northing));
     }
 
-    if (allHeights.length === 0) {
+    var exitCode = Execute("curl", args);
+    if (exitCode !== 0) {
+        recordApiFailure("curl exit code " + exitCode, true);
+    }
+    for (var i = 0; i < batch.length; i++) {
+        batch[i].swisstopoHeight = parseHeightResponse(responseFiles[i]);
+    }
+}
+
+function parseHeightResponse(responseFilePath) {
+    var file = SFile.New(responseFilePath);
+    if (!file.Exists()) {
+        recordApiFailure("no response file (transfer failed)", false);
         return null;
     }
+    if (!file.Open(SFile.ReadOnly)) {
+        recordApiFailure("response file could not be read", false);
+        return null;
+    }
+    var text = file.ReadAll();
+    file.Close();
+    file.Remove();
 
-    // Weighted average by point count
-    var totalWeight = 0;
+    if (!text) {
+        recordApiFailure("empty response from the server", false);
+        return null;
+    }
+    try {
+        var height = parseFloat(JSON.parse(text).height);
+        if (isNaN(height)) {
+            recordApiFailure("response without a height value: " + text.slice(0, 80), false);
+            return null;
+        }
+        return height;
+    } catch (parseError) {
+        recordApiFailure("invalid response: " + text.slice(0, 80), false);
+        return null;
+    }
+}
+
+/**
+ * Resolve the swisstopo reference height for all grid points: curl batches
+ * first, then one single-request retry pass for every point that is still
+ * missing, so transient failures do not end up as API_FAILED.
+ */
+function fetchReferenceHeights(results) {
+    var pending = results.filter(function (r) { return r.classification !== CLASS_NO_DATA; });
+    if (pending.length === 0) {
+        return;
+    }
+
+    var batchCount = Math.ceil(pending.length / API_BATCH_SIZE);
+    for (var b = 0; b < batchCount; b++) {
+        var batch = pending.slice(b * API_BATCH_SIZE, (b + 1) * API_BATCH_SIZE);
+        fetchHeightBatchViaCurl(batch);
+        print("swisstopo lookup: batch " + (b + 1) + "/" + batchCount +
+            " (" + Math.min((b + 1) * API_BATCH_SIZE, pending.length) + "/" + pending.length + " points)");
+    }
+
+    var missing = pending.filter(function (r) { return r.swisstopoHeight === null; });
+    if (missing.length > 0) {
+        print("Fetching " + missing.length + " missing reference heights one by one ...");
+        for (var i = 0; i < missing.length; i++) {
+            fetchHeightBatchViaCurl([missing[i]]);
+            if ((i + 1) % 25 === 0 || i === missing.length - 1) {
+                print("Single request: " + (i + 1) + "/" + missing.length);
+            }
+        }
+    }
+}
+
+// ==================== Cloud Height Extraction ====================
+
+/**
+ * Estimate the ground height in the cloud(s) around a grid point, weighted by
+ * point count across all clouds. The search cylinder spans the full vertical
+ * extent of the data, so even grossly wrong heights are found and classified
+ * as FAILED instead of silently producing NO_DATA.
+ */
+function getCloudHeightAtPoint(clouds, centerX, centerY, zRange, radius) {
+    var axis = SVector.New(0, 0, 1);
+    var cylinderHeight = zRange.maxZ - zRange.minZ + 2.0;
+    var cylinderCenter = SPoint.New(centerX, centerY, zRange.minZ - 1.0);
+    var cylinder = SCylinder.New(cylinderCenter, axis, radius, cylinderHeight);
+
     var weightedSum = 0;
-    for (var i = 0; i < allHeights.length; i++) {
-        var weight = allHeights[i].pointCount;
-        weightedSum += allHeights[i].height * weight;
+    var totalWeight = 0;
+
+    for (var i = 0; i < clouds.length; i++) {
+        var local = separateLocalCloud(clouds[i], cylinder);
+        if (local === null) {
+            continue;
+        }
+        var groundHeight = estimateGroundHeight(local, centerX, centerY, radius, axis);
+        var weight = local.GetNumber();
+        weightedSum += groundHeight * weight;
         totalWeight += weight;
     }
 
     return totalWeight > 0 ? weightedSum / totalWeight : null;
 }
 
-// -------------------- MAIN VALIDATION PROCESS -----------
-
-// Calculate bounding box
-var combinedMinX = Number.MAX_VALUE;
-var combinedMaxX = Number.MIN_VALUE;
-var combinedMinY = Number.MAX_VALUE;
-var combinedMaxY = Number.MIN_VALUE;
-
-for (var cloudIdx = 0; cloudIdx < selectedClouds.length; cloudIdx++) {
-    var cloud = selectedClouds[cloudIdx];
-    var bbox = cloud.GetBoundingBox();
-
-    combinedMinX = Math.min(combinedMinX, bbox.LowPoint.GetX());
-    combinedMaxX = Math.max(combinedMaxX, bbox.UpPoint.GetX());
-    combinedMinY = Math.min(combinedMinY, bbox.LowPoint.GetY());
-    combinedMaxY = Math.max(combinedMaxY, bbox.UpPoint.GetY());
+function separateLocalCloud(cloud, cylinder) {
+    var separated = cloud.SeparateFeature(cylinder, 0, SCloud.FILL_IN_ONLY);
+    if (separated.ErrorCode !== 0 || !separated.InCloud) {
+        return null;
+    }
+    if (separated.InCloud.GetNumber() <= MIN_LOCAL_POINTS) {
+        return null;
+    }
+    return separated.InCloud;
 }
 
-print("Bounding box: X(" + combinedMinX.toFixed(1) + " - " + combinedMaxX.toFixed(1) +
-    "), Y(" + combinedMinY.toFixed(1) + " - " + combinedMaxY.toFixed(1) + ")");
+/**
+ * Approximate ground height as the center of the lowest cloud slice. For nearly
+ * flat patches the bounding-box mid height is sufficient.
+ */
+function estimateGroundHeight(localCloud, centerX, centerY, radius, axis) {
+    var bbox = localCloud.GetBoundingBox();
+    var minZ = bbox.LowPoint.GetZ();
+    var maxZ = bbox.UpPoint.GetZ();
+    var range = maxZ - minZ;
 
-// Process validation points
-var results = [];
-var pointCount = 0;
+    if (range <= 0.5) {
+        return (minZ + maxZ) / 2;
+    }
 
-for (var currentX = combinedMinX; currentX <= combinedMaxX; currentX += GRID_SPACING) {
-    for (var currentY = combinedMinY; currentY <= combinedMaxY; currentY += GRID_SPACING) {
-        pointCount++;
-        print("\n--- Processing Point " + pointCount + " ---");
-        print("Coordinates: E=" + currentX.toFixed(1) + ", N=" + currentY.toFixed(1));
+    var sliceHeight = Math.max(0.1, range * 0.15);
+    var sliceCenter = SPoint.New(centerX, centerY, minZ + sliceHeight / 2);
+    var sliceCylinder = SCylinder.New(sliceCenter, axis, radius, sliceHeight);
+    var slice = localCloud.SeparateFeature(sliceCylinder, 0, SCloud.FILL_IN_ONLY);
 
-        var result = {
-            pointIndex: pointCount,
-            easting: currentX,
-            northing: currentY,
-            swisstopoHeight: null,
-            measuredHeight: null,
-            heightDiff: null,
-            classification: "UNKNOWN"
-        };
+    if (slice.ErrorCode === 0 && slice.InCloud && slice.InCloud.GetNumber() > 3) {
+        var sliceBox = slice.InCloud.GetBoundingBox();
+        return (sliceBox.LowPoint.GetZ() + sliceBox.UpPoint.GetZ()) / 2;
+    }
+    return minZ + range * 0.25; // fallback: lower quartile
+}
 
-        // Get Swisstopo height
-        result.swisstopoHeight = getSwisstopoHeight(currentX, currentY);
-        if (result.swisstopoHeight === null) {
-            print("❌ Swisstopo API failed");
-            result.classification = "API_FAILED";
-            results.push(result);
+// ==================== Grid Validation ====================
+
+function computeBoundingBox(clouds) {
+    var minX = Number.MAX_VALUE, maxX = -Number.MAX_VALUE;
+    var minY = Number.MAX_VALUE, maxY = -Number.MAX_VALUE;
+    var minZ = Number.MAX_VALUE, maxZ = -Number.MAX_VALUE;
+
+    for (var i = 0; i < clouds.length; i++) {
+        var bbox = clouds[i].GetBoundingBox();
+        minX = Math.min(minX, bbox.LowPoint.GetX());
+        maxX = Math.max(maxX, bbox.UpPoint.GetX());
+        minY = Math.min(minY, bbox.LowPoint.GetY());
+        maxY = Math.max(maxY, bbox.UpPoint.GetY());
+        minZ = Math.min(minZ, bbox.LowPoint.GetZ());
+        maxZ = Math.max(maxZ, bbox.UpPoint.GetZ());
+    }
+    return { minX: minX, maxX: maxX, minY: minY, maxY: maxY, minZ: minZ, maxZ: maxZ };
+}
+
+/**
+ * Phase 1: measure the local cloud height on every grid point (no network).
+ * Phase 2: fetch the swisstopo reference in batches, then classify.
+ */
+function validateGrid(clouds, params) {
+    var bounds = computeBoundingBox(clouds);
+    var results = measureGridHeights(clouds, bounds, params);
+
+    var withData = results.filter(function (r) { return r.classification !== CLASS_NO_DATA; });
+    print("Grid: " + results.length + " points, " + withData.length + " with point-cloud data.");
+
+    fetchReferenceHeights(results);
+    classifyResults(results, params.tolerance);
+    return results;
+}
+
+function measureGridHeights(clouds, bounds, params) {
+    var results = [];
+    var index = 0;
+
+    for (var x = bounds.minX; x <= bounds.maxX; x += params.gridSpacing) {
+        for (var y = bounds.minY; y <= bounds.maxY; y += params.gridSpacing) {
+            index++;
+            var measured = getCloudHeightAtPoint(clouds, x, y, bounds, params.searchRadius);
+            results.push({
+                pointIndex: index, easting: x, northing: y,
+                measuredHeight: measured, swisstopoHeight: null, heightDiff: null,
+                classification: measured === null ? CLASS_NO_DATA : CLASS_API_FAILED
+            });
+        }
+    }
+    return results;
+}
+
+function classifyResults(results, tolerance) {
+    for (var i = 0; i < results.length; i++) {
+        var result = results[i];
+        if (result.classification === CLASS_NO_DATA || result.swisstopoHeight === null) {
             continue;
         }
-        print("✓ Swisstopo height: " + result.swisstopoHeight.toFixed(3) + "m");
-
-        // Get cloud height
-        result.measuredHeight = getCloudHeightAtPoint(
-            selectedClouds,
-            currentX,
-            currentY,
-            result.swisstopoHeight,
-            SEARCH_RADIUS
-        );
-
-        if (result.measuredHeight === null) {
-            print("❌ No cloud data found");
-            result.classification = "NO_DATA";
-            results.push(result);
-            continue;
-        }
-        print("✓ Measured height: " + result.measuredHeight.toFixed(3) + "m");
-
-        // Calculate difference
         result.heightDiff = result.measuredHeight - result.swisstopoHeight;
-        var absDiff = Math.abs(result.heightDiff);
-        print("Difference: " + (result.heightDiff >= 0 ? "+" : "") + result.heightDiff.toFixed(3) + "m");
-
-        // Classify
-        if (absDiff <= ERROR_THRESHOLD) {
-            result.classification = "OK";
-            print("✓ Classification: OK");
-        } else {
-            result.classification = "ERROR";
-            print("❌ Classification: ERROR (exceeds " + ERROR_THRESHOLD + "m)");
-        }
-
-        // Create label (for all points if enabled, or just errors)
-        if (CREATE_ALL_LABELS || result.classification === "ERROR") {
-            try {
-                var gridPoint = SPoint.New(currentX, currentY, result.measuredHeight);
-                var label = SLabel.New(5, 2); // 5 rows for complete information
-
-                // Set column types: Measure and Reference
-                label.SetColType([SLabel.Measure, SLabel.Reference]);
-
-                // Set line types for different data rows
-                label.SetLineType([
-                    SLabel.Distance,    // Measured height
-                    SLabel.Distance,    // Swisstopo height  
-                    SLabel.Deviation,   // Difference (deviation) - this is the key measurement
-                    SLabel.EmptyLine,   // Point ID
-                    SLabel.EmptyLine    // Grid coordinates
-                ]);
-
-                // Row 0: Measured height
-                label.SetCell(0, 0, parseFloat(result.measuredHeight.toFixed(3)));
-                label.SetCell(0, 1, parseFloat(1)); // Code 1 = Measured
-
-                // Row 1: Swisstopo reference height
-                label.SetCell(1, 0, parseFloat(result.swisstopoHeight.toFixed(3)));
-                label.SetCell(1, 1, parseFloat(2)); // Code 2 = Swisstopo Reference
-
-                // Row 2: Height difference (deviation) - most important row
-                label.SetCell(2, 0, parseFloat(result.heightDiff.toFixed(3)));
-                label.SetCell(2, 1, parseFloat(3)); // Code 3 = Deviation
-
-                // Row 3: Point ID for reference
-                label.SetCell(3, 0, parseFloat(pointCount));
-                label.SetCell(3, 1, parseFloat(4)); // Code 4 = Point ID
-
-                // Row 4: Grid coordinates for location reference
-                label.SetCell(4, 0, parseFloat(currentX.toFixed(1))); // Easting
-                label.SetCell(4, 1, parseFloat(currentY.toFixed(1))); // Northing
-
-                // Set global tolerance based on classification
-                if (result.classification === "ERROR") {
-                    // Stricter tolerance for error points to highlight them
-                    label.SetTolerance(-ERROR_THRESHOLD, ERROR_THRESHOLD);
-                } else {
-                    // More lenient tolerance for OK points
-                    label.SetTolerance(-WARNING_THRESHOLD, WARNING_THRESHOLD);
-                }
-
-                // Enhanced comment with classification and deviation info
-                var labelComment = "Validation_" + result.classification + "_P" + pointCount +
-                    "_Δ" + (result.heightDiff >= 0 ? "+" : "") + result.heightDiff.toFixed(3) + "m";
-                label.SetComment(labelComment);
-
-                // Attach to point and add to document
-                label.AttachToPoint(gridPoint);
-                label.AddToDoc();
-
-                // Move to classification-specific group for better organization
-                var groupName = "Validation_" + result.classification + "_Labels";
-                label.MoveToGroup(groupName, true);
-
-                print("✓ Enhanced label created: " + labelComment);
-            } catch (labelError) {
-                print("⚠ Enhanced label creation failed: " + labelError.message);
-                print("  Falling back to basic label...");
-
-                // Robust fallback to basic 3-row label
-                try {
-                    var basicLabel = SLabel.New(3, 2);
-                    basicLabel.SetColType([SLabel.Measure, SLabel.Reference]);
-                    basicLabel.SetLineType([SLabel.Distance, SLabel.Distance, SLabel.Deviation]);
-
-                    // Basic data: measured, reference, difference
-                    basicLabel.SetCell(0, 0, parseFloat(result.measuredHeight.toFixed(3)));
-                    basicLabel.SetCell(0, 1, parseFloat(1)); // Measured
-                    basicLabel.SetCell(1, 0, parseFloat(result.swisstopoHeight.toFixed(3)));
-                    basicLabel.SetCell(1, 1, parseFloat(2)); // Reference
-                    basicLabel.SetCell(2, 0, parseFloat(result.heightDiff.toFixed(3)));
-                    basicLabel.SetCell(2, 1, parseFloat(3)); // Deviation
-
-                    // Set appropriate tolerance
-                    basicLabel.SetTolerance(-ERROR_THRESHOLD, ERROR_THRESHOLD);
-
-                    // Simple comment
-                    basicLabel.SetComment("VAL_" + result.classification + "_" + pointCount);
-                    basicLabel.AttachToPoint(gridPoint);
-                    basicLabel.AddToDoc();
-                    basicLabel.MoveToGroup("Validation_Labels", true);
-
-                    print("✓ Basic fallback label created");
-                } catch (fallbackError) {
-                    print("❌ All label creation attempts failed: " + fallbackError.message);
-                }
-            }
-        }
-
-        results.push(result);
+        result.classification =
+            Math.abs(result.heightDiff) <= tolerance ? CLASS_OK : CLASS_ERROR;
     }
 }
 
-// -------------------- RESULTS -----------
+// ==================== Summary & Report ====================
 
-print("\n=== Validation Results ===");
-var okCount = 0;
-var errorCount = 0;
-var failedCount = 0;
+function summarize(results) {
+    var summary = { total: results.length, ok: 0, error: 0, noData: 0, apiFailed: 0 };
+    for (var i = 0; i < results.length; i++) {
+        switch (results[i].classification) {
+            case CLASS_OK: summary.ok++; break;
+            case CLASS_ERROR: summary.error++; break;
+            case CLASS_NO_DATA: summary.noData++; break;
+            default: summary.apiFailed++; break;
+        }
+    }
+    return summary;
+}
 
-for (var i = 0; i < results.length; i++) {
-    var result = results[i];
-    switch (result.classification) {
-        case "OK": okCount++; break;
-        case "ERROR": errorCount++; break;
-        default: failedCount++; break;
+function buildCsv(results, params) {
+    var lines = [[
+        "Point_ID", "Easting", "Northing", "Measured_Height_m",
+        "Swisstopo_Height_m", "Difference_m", "Classification",
+        "Grid_Spacing_m", "Search_Radius_m", "Tolerance_m"
+    ].join(",")];
+
+    for (var i = 0; i < results.length; i++) {
+        var r = results[i];
+        lines.push([
+            r.pointIndex,
+            r.easting.toFixed(2),
+            r.northing.toFixed(2),
+            r.measuredHeight !== null ? r.measuredHeight.toFixed(HEIGHT_DECIMALS) : "N/A",
+            r.swisstopoHeight !== null ? r.swisstopoHeight.toFixed(HEIGHT_DECIMALS) : "N/A",
+            r.heightDiff !== null ? r.heightDiff.toFixed(HEIGHT_DECIMALS) : "N/A",
+            r.classification,
+            params.gridSpacing,
+            params.searchRadius,
+            params.tolerance
+        ].join(","));
+    }
+    return lines.join("\n");
+}
+
+function exportCsvReport(results, params) {
+    var csvText = buildCsv(results, params);
+    var csvPath = GetSaveFileName("Save CSV report / CSV-Bericht speichern", "CSV files (*.csv)");
+
+    if (!csvPath || csvPath === "" || csvPath === "null") {
+        print("CSV export cancelled.");
+        return;
+    }
+    if (!csvPath.toLowerCase().endsWith(".csv")) {
+        csvPath += ".csv";
+    }
+
+    var file = SFile.New(csvPath);
+    if (file.Open(SFile.WriteOnly)) {
+        file.Write(csvText);
+        file.Close();
+        print("CSV saved: " + csvPath);
+    } else {
+        print("CSV could not be written: " + csvPath);
     }
 }
 
-print("Total points processed: " + results.length);
-print("OK: " + okCount);
-print("ERROR: " + errorCount);
-print("FAILED/NO_DATA: " + failedCount);
-
-// -------------------- GENERATE REPORT -----------
-if (GENERATE_REPORT) {
-    try {
-        print("Starting direct CSV generation...");
-
-        // Create CSV content directly
-        var csvContent = [];
-
-        // CSV Header
-        var csvHeader = [
-            "Point_ID",
-            "Easting",
-            "Northing",
-            "Measured_Height_m",
-            "Swisstopo_Height_m",
-            "Difference_m",
-            "Classification",
-            "Grid_Spacing_m",
-            "Search_Radius_m",
-            "Error_Threshold_m"
-        ].join(",");
-        csvContent.push(csvHeader);
-
-        print("Adding " + results.length + " data rows...");
-
-        // Add data rows
-        for (var i = 0; i < results.length; i++) {
-            var result = results[i];
-            var csvRow = [
-                result.pointIndex,
-                result.easting.toFixed(2),
-                result.northing.toFixed(2),
-                result.measuredHeight !== null ? result.measuredHeight.toFixed(3) : "N/A",
-                result.swisstopoHeight !== null ? result.swisstopoHeight.toFixed(3) : "N/A",
-                result.heightDiff !== null ? result.heightDiff.toFixed(3) : "N/A",
-                '"' + result.classification + '"', // Quote to handle potential commas
-                GRID_SPACING,
-                SEARCH_RADIUS,
-                ERROR_THRESHOLD
-            ].join(",");
-            csvContent.push(csvRow);
-        }
-
-        // Join all lines with newlines
-        var csvText = csvContent.join("\n");
-        print("CSV content prepared (" + csvContent.length + " lines)");
-
-        // Try to save CSV - Method 1: User dialog
-        var csvSaved = false;
-        try {
-            print("Opening CSV save dialog...");
-            var csvPath = GetSaveFileName("Save CSV Report", "CSV files (*.csv)");
-            print("User selected: " + (csvPath ? csvPath : "cancelled"));
-
-            if (csvPath && csvPath !== "" && csvPath !== "null") {
-                // Ensure .csv extension
-                if (!csvPath.toLowerCase().endsWith('.csv')) {
-                    csvPath += '.csv';
-                }
-
-                print("Saving CSV to: " + csvPath);
-                var csvFile = SFile.New(csvPath);
-
-                if (csvFile.Open(SFile.WriteOnly)) {
-                    var writeSuccess = csvFile.Write(csvText);
-                    csvFile.Close();
-                    print("CSV write result: " + writeSuccess);
-                    print("✓ CSV saved successfully to: " + csvPath);
-
-                    SDialog.Message(
-                        "CSV Report saved successfully!\n\nFile: " + csvPath + "\n\nContains " + results.length + " validation results.",
-                        SDialog.EMessageSeverity.Success,
-                        "CSV Export Complete"
-                    );
-                    csvSaved = true;
-                } else {
-                    print("❌ Could not open CSV file for writing: " + csvPath);
-                }
-            } else {
-                print("CSV save dialog cancelled");
-            }
-        } catch (csvSaveError) {
-            print("CSV save error: " + csvSaveError.message);
-        }
-
-        // Method 2: Fallback to temp directory
-        if (!csvSaved) {
-            try {
-                var now = new Date();
-                var year = now.getFullYear();
-                var month = String(now.getMonth() + 1).padStart(2, '0');
-                var day = String(now.getDate()).padStart(2, '0');
-                var hour = String(now.getHours()).padStart(2, '0');
-                var minute = String(now.getMinutes()).padStart(2, '0');
-                var timestamp = year + "-" + month + "-" + day + "_" + hour + "-" + minute;
-
-                var tempCsvPath = TempPath() + "Swisstopo_Validation_" + timestamp + ".csv";
-                print("Attempting fallback save to: " + tempCsvPath);
-
-                var tempCsvFile = SFile.New(tempCsvPath);
-                if (tempCsvFile.Open(SFile.WriteOnly)) {
-                    var tempWriteSuccess = tempCsvFile.Write(csvText);
-                    tempCsvFile.Close();
-                    print("Temp CSV write result: " + tempWriteSuccess);
-                    print("✓ CSV saved to temp location: " + tempCsvPath);
-
-                    SDialog.Message(
-                        "CSV Report saved to temp directory:\n\n" + tempCsvPath + "\n\nContains " + results.length + " validation results.\nYou can copy this file to your desired location.",
-                        SDialog.EMessageSeverity.Info,
-                        "CSV Saved to Temp"
-                    );
-                    csvSaved = true;
-                } else {
-                    print("❌ Could not save to temp location: " + tempCsvPath);
-                }
-            } catch (tempCsvError) {
-                print("Temp CSV save error: " + tempCsvError.message);
-            }
-        }
-
-        // Method 3: Console output as last resort
-        if (!csvSaved) {
-            print("❌ All CSV save attempts failed - outputting to console");
-            print("=== CSV CONTENT START ===");
-            print(csvText);
-            print("=== CSV CONTENT END ===");
-            print("Copy the above CSV content to create your own file");
-        }
-
-    } catch (reportError) {
-        print("CSV generation error: " + reportError.message);
+function buildApiDiagnosisText(summary) {
+    if (summary.apiFailed === 0) {
+        return "";
     }
+    var text = "\nAPI diagnosis / API-Diagnose: " + apiDiagnostics.httpErrors + " response errors / Antwortfehler, " +
+        apiDiagnostics.exceptions + " transfer errors / Übertragungsfehler (curl)";
+    if (apiDiagnostics.lastDetail !== "") {
+        text += "\nLast error / Letzter Fehler: " + apiDiagnostics.lastDetail;
+    }
+    return text + "\n";
 }
 
-// Show summary dialog
-try {
-    var summaryMessage =
-        "Swisstopo Validation Complete\n\n" +
-        "Points processed: " + results.length + "\n" +
-        "OK: " + okCount + "\n" +
-        "ERROR: " + errorCount + "\n" +
-        "FAILED/NO_DATA: " + failedCount + "\n\n" +
-        "Error threshold: " + ERROR_THRESHOLD + "m\n" +
-        "Labels created: " + (CREATE_ALL_LABELS ? "All points" : "Errors only") + "\n" +
-        "Report generated: " + (GENERATE_REPORT ? "Yes" : "No") + "\n\n" +
-        "Data source: © swisstopo";
-
+function showSummary(summary, params) {
     var severity = SDialog.EMessageSeverity.Success;
-    if (errorCount > 0) {
+    if (summary.error > 0) {
         severity = SDialog.EMessageSeverity.Warning;
-    } else if (failedCount > 0) {
+    } else if (summary.apiFailed > 0) {
         severity = SDialog.EMessageSeverity.Info;
     }
 
-    SDialog.Message(summaryMessage, severity, "Validation Complete");
-} catch (dialogError) {
-    print("Dialog error: " + dialogError.message);
+    SDialog.Message(
+        "EN: Validation complete.\n\n" +
+        "Grid points total: " + summary.total + "\n" +
+        "OK: " + summary.ok + "\n" +
+        "Over tolerance: " + summary.error + "\n" +
+        "Without cloud data: " + summary.noData + "\n" +
+        "API failures: " + summary.apiFailed + "\n" +
+        buildApiDiagnosisText(summary) + "\n" +
+        "Tolerance: " + params.tolerance.toFixed(2) + " m\n\n" +
+        "DE: Validierung abgeschlossen.\n\n" +
+        "Rasterpunkte gesamt: " + summary.total + "\n" +
+        "OK: " + summary.ok + "\n" +
+        "Über Toleranz: " + summary.error + "\n" +
+        "Ohne Wolkendaten: " + summary.noData + "\n" +
+        "API-Fehler: " + summary.apiFailed + "\n\n" +
+        "Toleranz: " + params.tolerance.toFixed(2) + " m\n\n" +
+        "Data source / Datenquelle: (c) swisstopo (LV95 / EPSG:2056)",
+        severity, SCRIPT_TITLE
+    );
 }
 
-print("\n=== Swisstopo Validation Session End ===");
-print("✓ Validation completed successfully!");
-print("");
-print("Data source: © swisstopo - Height data from api3.geo.admin.ch");
-print("Coordinate system: LV95 (EPSG:2056)");
-print("Script: Swisstopo Systematic Point Cloud Validation v1.0");
+/**
+ * The engine sometimes throws strings or objects without a message property;
+ * a plain error.message then reads "undefined". Always produce readable text.
+ */
+function formatError(error) {
+    if (error === null || error === undefined) {
+        return "EN: Unknown exception without an error message (engine error).\n" +
+            "DE: Unbekannte Ausnahme ohne Fehlermeldung (Engine-Fehler).";
+    }
+    if (typeof error === "string") {
+        return error;
+    }
+    if (typeof error.message === "string" && error.message.length > 0) {
+        return error.message;
+    }
+    try {
+        return "Unexpected error object / Unerwartetes Fehlerobjekt: " + JSON.stringify(error);
+    } catch (stringifyError) {
+        return "Unexpected error object / Unerwartetes Fehlerobjekt: " + String(error);
+    }
+}
+
+function handleError(error) {
+    var text = formatError(error);
+    print("ERROR: " + text);
+    if (error && typeof error.stack === "string") {
+        print("Stack:\n" + error.stack);
+    }
+    SDialog.Message(text, SDialog.EMessageSeverity.Error, SCRIPT_TITLE);
+}
+
+// ==================== Entry Point ====================
+
+main();

--- a/COMMUNITY SCRIPTS/Swisstopo validation/README.md
+++ b/COMMUNITY SCRIPTS/Swisstopo validation/README.md
@@ -1,112 +1,97 @@
 # Swisstopo Height Validation Tool for Cyclone 3DR
-Created by Bimatic, Jan Sigrist - for any Questions and Feedback contact me at jan.sigrist@bimatic.ch
 
-## Description / Beschreibung
+| Script info |  |
+| -------- | ------- |
+| Contact | Jan Sigrist, Bimatic GmbH |
+| Email | jan.sigrist@bimatic.ch |
 
-**English:**
-Interactive quality control tool for comparing elevation data against swisstopo reference heights. Click on any point in your mesh or point cloud to instantly compare local height measurements with swisstopo data. Note: Swisstopo data should be used as a reference aid only, as there may be an undetermined time span between the acquisition of swisstopo data and the object being controlled.
+## Description
 
-**Deutsch:**
-Interaktives Qualitätskontroll-Tool zum Vergleich von Höhendaten gegen swisstopo-Referenzhöhen. Klicken Sie auf beliebige Punkte in Ihrem Mesh oder Ihrer Punktwolke, um lokale Höhenmessungen sofort mit swisstopo-Daten zu vergleichen. Hinweis: Swisstopo-Daten sind nur als Hilfsmittel zu betrachten, da zwischen der Erfassung der swisstopo-Daten und dem zu kontrollierenden Objekt eine unbestimmte Zeitspanne liegen kann.
+Interactive quality control tool for comparing elevation data against official swisstopo reference heights. Click on any point in a mesh or point cloud and the script instantly compares the local height against the swisstopo height API.
 
-## Features
+swisstopo data should be used as a reference aid only: there can be an undetermined time span between the acquisition of the swisstopo reference data and the object being controlled.
 
-- Interactive point selection with instant height comparison
-- Real-time validation against swisstopo API
-- Automatic label creation with pass/fail results
-- Configurable warning thresholds
-- Automatic grouping of validation labels
-- Bilingual interface (EN/DE)
+**Deutsch:** Interaktives Qualitätskontroll-Tool zum Vergleich von Höhendaten gegen swisstopo-Referenzhöhen. Klicken Sie auf beliebige Punkte in Ihrem Mesh oder Ihrer Punktwolke, um lokale Höhenmessungen sofort mit swisstopo-Daten zu vergleichen. Swisstopo-Daten sind nur als Hilfsmittel zu betrachten, da zwischen der Erfassung der swisstopo-Daten und dem zu kontrollierenden Objekt eine unbestimmte Zeitspanne liegen kann.
 
-## Requirements
+### What's new (2026-09-01)
 
-### Software
-- **Leica Cyclone 3DR 2025.1.4** or compatible version
-- **curl** command-line tool (must be in system PATH)
-- Internet connection for swisstopo API access
+- **Continuous workflow**: no more "continue?" dialog after every click. The script keeps validating until Esc; a per-point result popup is now opt-in (off by default) instead of forced.
+- **Session summary**: on exit, one dialog reports how many points were checked, how many passed, how many exceeded tolerance, how many lookups failed, the mean deviation and the largest absolute deviation.
+- **Coordinate guardrail**: a point clicked outside Switzerland's LV95 extent is caught immediately with a clear message instead of surfacing as an unexplained API failure.
+- **Bilingual dialogs**: field names, tooltips and messages are English / German throughout.
+- **Reliable transport**: height lookups go through a curl subprocess with a 30 second timeout. The script engine's own `fetch()` API intermittently fails inside the GUI process with an SSL certificate-chain error when calling `api3.geo.admin.ch`; curl as a separate process is not affected.
+- **Readable failures**: every error names the step it happened in, and the message is never blank, even for exceptions the engine throws as bare strings or objects.
 
-### Data Requirements
-- **Coordinate System**: LV95 (EPSG:2056)
-- **Coverage Area**: Switzerland and Liechtenstein
-- **Data Types**: Point clouds, meshes, or any clickable 3D geometry
+![UI](UI.png)
+![Validation passed](Validation%20passed.png)
+![Validation failed](Validation%20failed.png)
 
-## Installation
+## Tested version
 
-1. Download `SwisstopoHeightValidation.js` or the whole folder.
-2. Place in Cyclone 3DR scripts directory:
-   - `C:\Users\[Username]\Documents\3DReshaper Scripts\`
+- Cyclone 3DR 2026.1.2.50530 (headless and interactive)
+- Should run on Cyclone 3DR 2025.1 or newer (no dependency on the 2026.1.2 `fetch()` runtime)
+
+## Licensing
+
+Free to use and adapt, no warranty. Compatible with any Cyclone 3DR edition (Standard, Survey, Advanced).
 
 ## Usage
 
-### Configuration
-1. **Run script**: `Scripts` → `Execute Script` → `Load` → `SwisstopoHeightValidation.js`
-2. **Set warning threshold**: Maximum acceptable height difference (recommended: 0.2-1.0m)
-3. **Enable auto-labels**: Automatically create validation labels
-4. **Show coordinates**: Include LV95 coordinates in labels (optional)
+1. Run the script from the Cyclone 3DR Scripts menu.
+2. Set the tolerance, and optionally enable per-point popups.
+3. Click points in your 3D data. Labels are created automatically (unless disabled); out-of-tolerance points additionally get a red marker sphere.
+4. Press **Esc** to stop. A summary dialog reports the session statistics.
 
-### Validation Process
-1. **Click on points** in your 3D data to validate heights
-2. **Review results** in the popup dialog
-3. **Check labels** created automatically in the document
-4. **Continue validation** or finish session
+### Label information
 
-### Label Information
-Labels contain numeric values only:
-- **Row 1**: Local height (measured)
-- **Row 2**: Swisstopo reference height
-- **Row 3**: Height difference (local - swisstopo)
-- **Row 4-5**: Coordinates (if enabled)
+Each label has 3 columns:
+- **Measure**: local height at the clicked point
+- **Reference**: swisstopo reference height
+- **Deviation**: local minus reference
 
-Label comments show validation result:
-- `VALIDATION_PASSED`: Difference within threshold
-- `VALIDATION_FAILED`: Difference exceeds threshold
+The label comment states the verdict ("OK" or "Deviation ... > tolerance ..."), and labels are grouped under `Swisstopo Validation/OK` or `Swisstopo Validation/FAILED`.
 
-## Technical Details
+## Requirements
 
-### API Information
-- **Endpoint**: https://api3.geo.admin.ch/rest/services/height
-- **Coordinate System**: LV95 (EPSG:2056)
-- **Data Source**: swisstopo DTM-AV
-- **Coverage**: Switzerland and Liechtenstein
+- **Leica Cyclone 3DR 2025.1** or newer
+- **curl** command-line tool (built into Windows 10/11, must be on PATH)
+- Internet connection to `api3.geo.admin.ch`
+- Project georeferenced in **LV95 (EPSG:2056)**, coverage area Switzerland and Liechtenstein
 
-### Label Format
-Due to Cyclone 3DR 2025.1.4 API requirements:
-- All label cells contain **numeric values only**
-- Text information is stored in label comments
-- Numeric codes: 1=Local, 2=Swisstopo, 3=Difference, 4=Easting, 5=Northing
+## Technical details
+
+- **API**: `https://api3.geo.admin.ch/rest/services/height?easting={E}&northing={N}&sr=2056&format=json`
+- **Coordinate system**: LV95 (EPSG:2056)
+- **Data source**: swisstopo DTM-AV, via `api3.geo.admin.ch`
 
 ## Troubleshooting
 
 | Problem | Solution |
 |---------|----------|
-| "curl command not found" | Install curl or add to system PATH |
-| "API request failed" | Check internet connection |
-| "No points generated" | Verify LV95 coordinates within Switzerland |
-| Label creation fails | Ensure using Cyclone 3DR 2025.1.4+ |
+| "swisstopo API unreachable" | Check internet connection / firewall / proxy for curl |
+| Point silently skipped | Point is outside the LV95 extent of Switzerland |
+| No labels created | Check that "Create labels automatically" is enabled |
 
-## Data Limitations
+## Data limitations
 
-- **Temporal Accuracy**: Time difference between swisstopo data acquisition and surveyed object
-- **Spatial Resolution**: swisstopo DTM resolution limitations
-- **Reference Purpose**: Data should be used for reference comparison only
-- **Professional Verification**: Critical measurements require professional survey validation
+- **Temporal accuracy**: there can be a significant time gap between swisstopo data acquisition and the surveyed object.
+- **Reference purpose only**: use for QA / plausibility checks, not as a substitute for a professional survey validation where that is required.
 
-## Version History
+## Files
 
-- **v2.1**: Fixed for Cyclone 3DR 2025.1.4 - numeric labels only
-- **v2.0**: Enhanced bilingual interface and error handling
-- **v1.0**: Initial release
+- Main script: [Swisstopo validation.js](./Swisstopo%20validation.js)
+
+## Version history
+
+- **2026-09-01**: Continuous workflow, session summary, LV95 guardrail, bilingual dialogs, curl-based transport, readable error handling
+- **v2.1** (Cyclone 3DR 2025.1.4): numeric-only label cells
+- **v2.0**: enhanced bilingual interface and error handling
+- **v1.0** (2025-08-25): initial release
 
 ---
 
-## Disclaimer / Haftungsausschluss
+## Disclaimer
 
-**English:**
-This tool provides reference comparisons for quality control purposes only. Swisstopo data should be used as a reference aid, as there may be an undetermined time span between swisstopo data acquisition and the object being controlled. Users must verify data accuracy for their specific applications and comply with professional surveying standards. Use at your own risk.
+This tool provides reference comparisons for quality control purposes only. swisstopo data should be used as a reference aid; there may be an undetermined time span between swisstopo data acquisition and the object being controlled. Verify data accuracy for your specific application and comply with professional surveying standards where required. Use at your own risk.
 
-**Deutsch:**
-Dieses Tool bietet Referenzvergleiche nur für Qualitätskontrollzwecke. Swisstopo-Daten sind als Hilfsmittel zu betrachten, da zwischen der Erfassung der swisstopo-Daten und dem zu kontrollierenden Objekt eine unbestimmte Zeitspanne liegen kann. Benutzer müssen die Datengenauigkeit für ihre spezifischen Anwendungen überprüfen und professionelle Vermessungsstandards einhalten. Nutzung auf eigene Gefahr.
-
-**Data Attribution:**
-© swisstopo - Swiss Federal Office of Topography  
-Height data from api3.geo.admin.ch
+**Data attribution:** (c) swisstopo - Swiss Federal Office of Topography. Height data from `api3.geo.admin.ch`.

--- a/COMMUNITY SCRIPTS/Swisstopo validation/Swisstopo validation.js
+++ b/COMMUNITY SCRIPTS/Swisstopo validation/Swisstopo validation.js
@@ -1,346 +1,392 @@
-/// <reference path="C:/Program Files/Leica Geosystems/Cyclone 3DR/Script/JsDoc/Reshaper.d.ts"/>
-
-// -----------------------------------------------------------------------------
-//  SwisstopoHeightValidation.js – v1.0 (2025-08-25)
-// -----------------------------------------------------------------------------
-//  ENGLISH: Height validation tool - for Cyclone 3DR 2025.1.4
-//  DEUTSCH: Höhenvalidierungstool - für Cyclone 3DR 2025.1.4
-//  Author: Jan Sigrist (Bimatic GmbH) - www.bimatic.ch
-// -----------------------------------------------------------------------------
-
-// -------------------- CONFIGURATION DIALOG / KONFIGURATIONSDIALOG -----------
-var dlg = SDialog.New("Swisstopo Height Validation / Höhenvalidierung");
-dlg.AddText("EN: Click on points to validate height against swisstopo reference data", SDialog.EMessageSeverity.Instruction);
-dlg.AddText("DE: Auf Punkte klicken um Höhe gegen swisstopo-Referenzdaten zu validieren", SDialog.EMessageSeverity.Instruction);
-
-dlg.BeginGroup("Settings / Einstellungen");
-dlg.AddLength({
-    id: "tolerance",
-    name: "Warning threshold / Warngrenze [m]",
-    value: 0.5,
-    min: 0.01,
-    max: 10.0,
-    saveValue: true,
-    tooltip: "EN: Show warning if difference exceeds this value | DE: Warnung anzeigen wenn Differenz diesen Wert überschreitet"
-});
-
-dlg.AddBoolean({
-    id: "autoLabel",
-    name: "Auto-create labels / Automatische Beschriftungen",
-    value: true,
-    saveValue: true,
-    tooltip: "EN: Automatically create labels for each validation point | DE: Automatisch Beschriftungen für jeden Validierungspunkt erstellen"
-});
-
-dlg.AddBoolean({
-    id: "showCoords",
-    name: "Show coordinates / Koordinaten anzeigen",
-    value: false,
-    saveValue: true,
-    tooltip: "EN: Include LV95 coordinates in labels | DE: LV95-Koordinaten in Beschriftungen einbeziehen"
-});
-
-var config = dlg.Run();
-if (config.ErrorCode !== 0) {
-    throw new Error("Operation cancelled by user / Vorgang vom Benutzer abgebrochen");
-}
-
-var WARNING_THRESHOLD = config.tolerance;
-var AUTO_LABEL = config.autoLabel;
-var SHOW_COORDINATES = config.showCoords;
-
-// -------------------- HELPER FUNCTIONS / HILFSFUNKTIONEN --------------------
+/// <reference path="C:/Program Files/Leica Geosystems/Cyclone 3DR/Script/JsDoc/Reshaper.d.ts" />
+// @ts-check
 
 /**
- * Retrieves height from swisstopo API using LV95 coordinates
+ * Script: Swisstopo Height Validation (interactive)
+ * Purpose: Click points to compare local height against the official swisstopo
+ *          height API. Keeps validating point after point until Esc, then
+ *          prints a session summary with deviation statistics.
+ * Note:    Web requests go through curl instead of the engine's fetch(). fetch()
+ *          intermittently fails inside the GUI process with an SSL
+ *          certificate-chain error ("Zertifikat des Ausstellers ... konnte
+ *          nicht gefunden werden"); curl as a separate process does not hit it.
+ * Author: Jan Sigrist (Bimatic GmbH)
+ * Contact: jan.sigrist@bimatic.ch
+ * Date: 2026-09-01
+ * Tested with: Cyclone 3DR 2026.1.2
+ * Requires: Cyclone 3DR 2025.1+, internet access, curl (built into Windows 10/11)
+ * Licensing: free to use and adapt, no warranty. Compatible with any Cyclone 3DR edition.
+ * Data source: api3.geo.admin.ch (LV95 / EPSG:2056), (c) swisstopo
+ */
+
+// ==================== Constants ====================
+
+var SCRIPT_TITLE = "Swisstopo Height Validation / Höhenvalidierung";
+var LOGO_PATH = CurrentScriptPath() + "/../Bimatic_white_just_Name.svg";
+var LABEL_GROUP = "Swisstopo Validation";
+var HEIGHT_DECIMALS = 3;
+var FAIL_COLOR = [0.9, 0.1, 0.1]; // red marker for out-of-tolerance points
+var MARKER_RADIUS = 0.25;         // marker sphere radius [m]
+
+// LV95 plausibility bounds (Switzerland)
+var LV95_MIN_E = 2450000, LV95_MAX_E = 2850000;
+var LV95_MIN_N = 1050000, LV95_MAX_N = 1310000;
+
+// ==================== Main Function ====================
+
+function main() {
+    try {
+        var params = getUserParameters();
+        configureLabelStyle();
+        var session = runValidationLoop(params);
+        showSessionSummary(session, params.tolerance);
+    } catch (error) {
+        handleError(error);
+    }
+}
+
+// ==================== User Input ====================
+
+function getUserParameters() {
+    var dialog = SDialog.New(SCRIPT_TITLE);
+    dialog.SetHeader(SCRIPT_TITLE, LOGO_PATH, 60);
+    dialog.AddText(
+        "EN: Click points to check their height against the swisstopo reference. Press ESC to stop.",
+        SDialog.EMessageSeverity.Instruction
+    );
+    dialog.AddText(
+        "DE: Punkte anklicken, um die Höhe gegen die Swisstopo-Referenz zu prüfen (ESC zum Beenden).",
+        SDialog.EMessageSeverity.Instruction
+    );
+
+    dialog.BeginGroup("Settings / Einstellungen");
+    dialog.AddLength({
+        id: "tolerance",
+        name: "Tolerance / Toleranz [m]",
+        value: 0.5,
+        min: 0.01,
+        max: 10.0,
+        saveValue: true,
+        tooltip: "EN: Deviations above this value are marked FAILED | DE: Abweichungen über diesem Wert gelten als FEHLER"
+    });
+    dialog.AddBoolean({
+        id: "autoLabel",
+        name: "Create labels automatically / Beschriftung automatisch erstellen",
+        value: true,
+        saveValue: true
+    });
+    dialog.AddBoolean({
+        id: "showPopups",
+        name: "Show a popup per point / Ergebnis-Popup pro Punkt anzeigen",
+        value: false,
+        saveValue: true,
+        tooltip: "EN: Off = results only as labels and in the log (faster workflow) | DE: Aus = Ergebnisse nur als Label und im Log (schnellerer Arbeitsfluss)"
+    });
+
+    // Run() is typed as {ErrorCode} only; the field ids are dynamic
+    var result = /** @type {any} */ (dialog.Run());
+    if (result.ErrorCode !== 0) {
+        throw new Error("EN: Cancelled by user. | DE: Vom Benutzer abgebrochen.");
+    }
+
+    return {
+        tolerance: result.tolerance,
+        autoLabel: result.autoLabel,
+        showPopups: result.showPopups
+    };
+}
+
+// ==================== Label Styling ====================
+
+/**
+ * Configure the global SLabel appearance once. SLabel color setters are static
+ * (global), so per-label coloring is impossible. The label uses a dark background
+ * with light text for readability; status is conveyed by the comment verdict and
+ * the OK / FAILED group.
+ */
+function configureLabelStyle() {
+    SLabel.SetDecimalNumber(HEIGHT_DECIMALS);
+    SLabel.SetSizeType(SLabel.LONG);
+    SLabel.SetBackgroundType(SLabel.SPECIAL_COLOR);
+    SLabel.SetBackgroundColor(0.13, 0.13, 0.13, 0.0);
+    SLabel.SetLineColor(0.95, 0.95, 0.95);
+}
+
+/**
+ * Create a self-explaining height label (columns Measure | Reference | Deviation).
+ * The verdict text and the OK / FAILED group flag the tolerance status.
+ */
+function createDeviationLabel(point, measuredHeight, referenceHeight, tolerance) {
+    var deviation = measuredHeight - referenceHeight;
+    var exceeded = Math.abs(deviation) > tolerance;
+    var statusGroup = LABEL_GROUP + "/" + (exceeded ? "FAILED" : "OK");
+
+    var label = SLabel.New(1, 3);
+    label.SetColType([SLabel.Measure, SLabel.Reference, SLabel.Deviation]);
+    label.SetLineType([SLabel.Level]);
+
+    label.SetCell(0, 0, parseFloat(measuredHeight.toFixed(HEIGHT_DECIMALS)));
+    label.SetCell(0, 1, parseFloat(referenceHeight.toFixed(HEIGHT_DECIMALS)));
+    label.SetCell(0, 2, parseFloat(deviation.toFixed(HEIGHT_DECIMALS)));
+
+    label.SetComment(buildVerdict(deviation, tolerance));
+    label.ShowComment(true);
+
+    label.AttachToPoint(point);
+    label.AddToDoc();
+    label.MoveToGroup(statusGroup, true);
+
+    if (exceeded) {
+        createFailMarker(point, statusGroup);
+    }
+}
+
+/**
+ * Red sphere marking an out-of-tolerance point. SComp.SetColors is per-instance
+ * and reliably rendered on geometry (unlike on labels), so this is the only way
+ * to get a real red flag per point.
+ */
+function createFailMarker(point, group) {
+    var sphere = SSphere.New(point, MARKER_RADIUS);
+    sphere.SetColors(FAIL_COLOR[0], FAIL_COLOR[1], FAIL_COLOR[2]);
+    sphere.SetName("FAILED");
+    sphere.AddToDoc();
+    sphere.MoveToGroup(group, false);
+}
+
+function buildVerdict(deviation, tolerance) {
+    var signed = (deviation >= 0 ? "+" : "") + deviation.toFixed(HEIGHT_DECIMALS) + " m";
+    if (Math.abs(deviation) > tolerance) {
+        return "Deviation " + signed + " > tolerance " + tolerance.toFixed(2) + " m";
+    }
+    return "OK  Deviation " + signed;
+}
+
+// ==================== Swisstopo API ====================
+
+var requestCounter = 0;
+
+/**
+ * Query the official swisstopo height for LV95 coordinates via curl (separate
+ * process, avoids the GUI fetch() SSL certificate problem). Returns null on
+ * any failure (network, HTTP error, invalid payload) with a log line.
  */
 function getSwisstopoHeight(easting, northing) {
     var apiUrl = "https://api3.geo.admin.ch/rest/services/height" +
         "?easting=" + easting +
         "&northing=" + northing +
-        "&sr=2056" +
-        "&format=json";
+        "&sr=2056&format=json";
 
-    var tempFileName = TempPath() + "swisstopo_validation_" +
-        Math.round(easting) + "_" + Math.round(northing) + ".json";
+    requestCounter++;
+    var responseFile = TempPath() + "swisstopo_click_" + requestCounter + ".json";
 
-    var curlResult = Execute("curl", ["-s", "-o", tempFileName, apiUrl]);
-    if (curlResult !== 0) {
+    var exitCode = Execute("curl", ["-sS", "-L", "-m", "30", "-o", responseFile, apiUrl]);
+    if (exitCode !== 0) {
+        print("swisstopo API unreachable (curl exit code " + exitCode + ").");
         return null;
     }
 
-    var responseFile = SFile.New(tempFileName);
-    var responseText = null;
-
-    if (responseFile.Open(SFile.ReadOnly)) {
-        responseText = responseFile.ReadAll();
-        responseFile.Close();
-        responseFile.Remove();
-    }
-
-    if (!responseText) {
+    var file = SFile.New(responseFile);
+    if (!file.Exists() || !file.Open(SFile.ReadOnly)) {
+        print("swisstopo response file could not be read.");
         return null;
     }
+    var text = file.ReadAll();
+    file.Close();
+    file.Remove();
 
+    if (!text) {
+        print("Empty response from the swisstopo API.");
+        return null;
+    }
     try {
-        var apiResponse = JSON.parse(responseText);
-        if (apiResponse.height !== undefined) {
-            var height = parseFloat(apiResponse.height);
-            return isNaN(height) ? null : height;
+        var height = parseFloat(JSON.parse(text).height);
+        if (isNaN(height)) {
+            print("swisstopo response without a height value: " + text.slice(0, 80));
+            return null;
         }
+        return height;
     } catch (parseError) {
-        return null;
-    }
-
-    return null;
-}
-
-/**
- * Creates a validation label with NUMBERS ONLY (Cyclone 3DR 2025.1.4 requirement)
- */
-function createValidationLabel(point, localHeight, swisstopoHeight, pointIndex) {
-    try {
-        var heightDiff = localHeight - swisstopoHeight;
-        var absDiff = Math.abs(heightDiff);
-        var isWarning = absDiff > WARNING_THRESHOLD;
-
-        // Determine label size based on options
-        var numRows = SHOW_COORDINATES ? 5 : 3;
-        var label = SLabel.New(numRows, 2);
-
-        // Set column and line types
-        label.SetColType([SLabel.Measure, SLabel.Reference]);
-
-        // Build line types array
-        var lineTypes = [SLabel.Distance, SLabel.Distance, SLabel.Deviation];
-        if (SHOW_COORDINATES) {
-            lineTypes.push(SLabel.EmptyLine);
-            lineTypes.push(SLabel.EmptyLine);
-        }
-        label.SetLineType(lineTypes);
-
-        // Fill label data - ONLY NUMBERS!
-        var rowIndex = 0;
-
-        // Row 0: Local height
-        label.SetCell(rowIndex, 0, parseFloat(localHeight.toFixed(3)));
-        label.SetCell(rowIndex, 1, 1); // Code for "Local" (1 = Local, 2 = Swisstopo, 3 = Diff)
-        rowIndex++;
-
-        // Row 1: Swisstopo height
-        label.SetCell(rowIndex, 0, parseFloat(swisstopoHeight.toFixed(3)));
-        label.SetCell(rowIndex, 1, 2); // Code for "Swisstopo"
-        rowIndex++;
-
-        // Row 2: Height difference
-        label.SetCell(rowIndex, 0, parseFloat(heightDiff.toFixed(3)));
-        label.SetCell(rowIndex, 1, 3); // Code for "Difference"
-        rowIndex++;
-
-        // Optional coordinate rows
-        if (SHOW_COORDINATES) {
-            // Row 3: Easting
-            label.SetCell(rowIndex, 0, parseFloat(point.GetX().toFixed(2)));
-            label.SetCell(rowIndex, 1, 4); // Code for "Easting"
-            rowIndex++;
-
-            // Row 4: Northing
-            label.SetCell(rowIndex, 0, parseFloat(point.GetY().toFixed(2)));
-            label.SetCell(rowIndex, 1, 5); // Code for "Northing"
-        }
-
-        // Set label properties with simple pass/fail comment
-        var labelComment;
-        if (isWarning) {
-            labelComment = "VALIDATION_FAILED";
-        } else {
-            labelComment = "VALIDATION_PASSED";
-        }
-
-        label.SetComment(labelComment);
-        label.AttachToPoint(point);
-        label.AddToDoc();
-
-        // Move to group
-        var groupName = "Height_Validation_Labels";
-        label.MoveToGroup(groupName, true);
-
-        return label;
-
-    } catch (labelError) {
-        print("Label creation error: " + labelError.message);
+        print("Invalid swisstopo response: " + text.slice(0, 80));
         return null;
     }
 }
 
-/**
- * Validates a single point and provides user feedback
- */
-function validatePoint(clickedPoint, pointIndex) {
-    var x = clickedPoint.GetX();
-    var y = clickedPoint.GetY();
-    var localHeight = clickedPoint.GetZ();
+// ==================== Validation ====================
 
-    print("=== Validation Point #" + pointIndex + " ===");
-    print("Coordinates: E=" + x.toFixed(3) + ", N=" + y.toFixed(3) + ", H=" + localHeight.toFixed(3));
-
-    // Get swisstopo reference height
-    print("Retrieving swisstopo data...");
-    var swisstopoHeight = getSwisstopoHeight(x, y);
-
-    if (swisstopoHeight === null) {
-        var errorMsg = "Failed to retrieve swisstopo height data!\n\nPossible causes:\n• Network connection issue\n• Point outside Switzerland\n• API temporarily unavailable";
-        SDialog.Message(errorMsg, SDialog.EMessageSeverity.Error, "API Error");
-        print("ERROR: API request failed");
-        return false;
-    }
-
-    // Calculate difference
-    var heightDiff = localHeight - swisstopoHeight;
-    var absDiff = Math.abs(heightDiff);
-
-    print("Swisstopo height: " + swisstopoHeight.toFixed(3) + "m");
-    print("Difference: " + (heightDiff >= 0 ? "+" : "") + heightDiff.toFixed(3) + "m");
-
-    // Create label if enabled
-    if (AUTO_LABEL) {
-        var label = createValidationLabel(clickedPoint, localHeight, swisstopoHeight, pointIndex);
-        if (label) {
-            print("✓ Label created: " + label.GetComment());
-        } else {
-            print("⚠ Label creation failed, but validation data is valid");
-        }
-    }
-
-    // Show result dialog
-    var resultMessage =
-        "Validation Result #" + pointIndex + "\n" +
-        "Validierungsergebnis #" + pointIndex + "\n\n" +
-        "Local height / Lokale Höhe: " + localHeight.toFixed(3) + "m\n" +
-        "Swisstopo ref / Referenz: " + swisstopoHeight.toFixed(3) + "m\n" +
-        "Difference / Differenz: " + (heightDiff >= 0 ? "+" : "") + heightDiff.toFixed(3) + "m\n";
-
-    if (SHOW_COORDINATES) {
-        resultMessage += "Coordinates / Koordinaten: E=" + x.toFixed(2) + ", N=" + y.toFixed(2) + "\n";
-    }
-
-    resultMessage += "\n";
-
-    var severity = SDialog.EMessageSeverity.Info;
-    var title = "Validation Result";
-
-    if (absDiff > WARNING_THRESHOLD) {
-        resultMessage += "⚠️ WARNING: Difference exceeds " + WARNING_THRESHOLD + "m threshold\n";
-        resultMessage += "⚠️ WARNUNG: Differenz überschreitet " + WARNING_THRESHOLD + "m Grenzwert\n";
-        resultMessage += "Please verify data accuracy / Bitte Datengenauigkeit prüfen";
-        severity = SDialog.EMessageSeverity.Warning;
-        title = "Height Difference Warning";
-    } else {
-        resultMessage += "✓ OK: Difference within acceptable range\n";
-        resultMessage += "✓ OK: Differenz im akzeptablen Bereich\n";
-        resultMessage += "Data appears plausible / Daten erscheinen plausibel";
-    }
-
-    SDialog.Message(resultMessage, severity, title);
-    return true;
+function isInsideLv95Bounds(point) {
+    var e = point.GetX();
+    var n = point.GetY();
+    return e >= LV95_MIN_E && e <= LV95_MAX_E && n >= LV95_MIN_N && n <= LV95_MAX_N;
 }
 
-// -------------------- MAIN VALIDATION LOOP / HAUPT-VALIDIERUNGSSCHLEIFE -----
+function validatePoint(point, params, session) {
+    var easting = point.GetX();
+    var northing = point.GetY();
+    var localHeight = point.GetZ();
+    var index = session.total + 1;
 
-print("=== Swisstopo Height Validation Tool Started ===");
-print("Version: Fixed for Cyclone 3DR 2025.1.4.47974");
-print("Click on points to validate (ESC to exit)");
-print("Labels use numeric codes: 1=Local, 2=Swisstopo, 3=Difference, 4=Easting, 5=Northing");
+    if (!isInsideLv95Bounds(point)) {
+        print("Point #" + index + " lies outside the LV95 bounds (E=" +
+            easting.toFixed(1) + ", N=" + northing.toFixed(1) + ") and is skipped.");
+        SDialog.Message(
+            "EN: This point lies outside Switzerland (LV95). The project must be\n" +
+            "georeferenced in LV95 / EPSG:2056.\n\n" +
+            "DE: Der Punkt liegt ausserhalb der Schweiz (LV95). Das Projekt muss\n" +
+            "in LV95 / EPSG:2056 georeferenziert sein.",
+            SDialog.EMessageSeverity.Warning, SCRIPT_TITLE
+        );
+        return;
+    }
 
-var validationCount = 0;
-var continueValidation = true;
+    var referenceHeight = getSwisstopoHeight(easting, northing);
+    if (referenceHeight === null) {
+        session.apiFailed++;
+        session.total++;
+        print("Point #" + index + ": swisstopo reference not available.");
+        return;
+    }
 
-while (continueValidation) {
-    print("\nWaiting for point selection... (ESC to exit)");
+    var deviation = localHeight - referenceHeight;
+    session.total++;
+    session.recordDeviation(deviation, params.tolerance);
 
-    try {
-        var clickResult = SPoint.FromClick();
+    if (params.autoLabel) {
+        createDeviationLabel(point, localHeight, referenceHeight, params.tolerance);
+    }
 
-        switch (clickResult.ErrorCode) {
-            case 0: // Point selected
-                validationCount++;
-                var success = validatePoint(clickResult.Point, validationCount);
+    print("Point #" + index +
+        "  local=" + localHeight.toFixed(HEIGHT_DECIMALS) +
+        "  swisstopo=" + referenceHeight.toFixed(HEIGHT_DECIMALS) +
+        "  dZ=" + (deviation >= 0 ? "+" : "") + deviation.toFixed(HEIGHT_DECIMALS) + " m");
 
-                if (success) {
-                    // Ask to continue
-                    var continueDialog = SDialog.New("Continue Validation?");
-                    continueDialog.AddText("Point #" + validationCount + " validated successfully", SDialog.EMessageSeverity.Success);
-                    continueDialog.AddText("Punkt #" + validationCount + " erfolgreich validiert", SDialog.EMessageSeverity.Success);
-                    continueDialog.SetButtons(["Validate Another / Weiteren validieren", "Finish / Beenden"]);
-
-                    var continueResult = continueDialog.Run();
-                    if (continueResult.ErrorCode !== 0) {
-                        continueValidation = false;
-                    }
-                } else {
-                    // Error occurred
-                    var retryDialog = SDialog.New("Validation Error");
-                    retryDialog.AddText("Error during validation", SDialog.EMessageSeverity.Error);
-                    retryDialog.AddText("Fehler bei der Validierung aufgetreten", SDialog.EMessageSeverity.Error);
-                    retryDialog.SetButtons(["Retry / Wiederholen", "Exit / Beenden"]);
-
-                    var retryResult = retryDialog.Run();
-                    if (retryResult.ErrorCode !== 0) {
-                        continueValidation = false;
-                    }
-                    validationCount--;
-                }
-                break;
-
-            case 1: // Nothing selected
-                break;
-
-            case 2: // ESC pressed
-                continueValidation = false;
-                print("Validation cancelled by user");
-                break;
-
-            default:
-                print("Selection error: " + clickResult.ErrorCode);
-                continueValidation = false;
-                break;
-        }
-
-    } catch (error) {
-        print("Error: " + error.message);
-        continueValidation = false;
+    if (params.showPopups) {
+        showPointResult(index, localHeight, referenceHeight, deviation, params.tolerance);
     }
 }
 
-// -------------------- FINAL REPORT / ABSCHLUSSBERICHT ------------------------
+function showPointResult(index, localHeight, referenceHeight, deviation, tolerance) {
+    var exceeded = Math.abs(deviation) > tolerance;
+    var signed = (deviation >= 0 ? "+" : "") + deviation.toFixed(HEIGHT_DECIMALS) + " m";
+    var message =
+        "EN: Local height: " + localHeight.toFixed(HEIGHT_DECIMALS) + " m\n" +
+        "swisstopo reference: " + referenceHeight.toFixed(HEIGHT_DECIMALS) + " m\n" +
+        "Deviation: " + signed + "\n" +
+        (exceeded
+            ? "Exceeds the tolerance of " + tolerance.toFixed(2) + " m."
+            : "Within the tolerance of " + tolerance.toFixed(2) + " m.") +
+        "\n\nDE: Lokale Höhe: " + localHeight.toFixed(HEIGHT_DECIMALS) + " m\n" +
+        "Swisstopo-Referenz: " + referenceHeight.toFixed(HEIGHT_DECIMALS) + " m\n" +
+        "Abweichung: " + signed + "\n" +
+        (exceeded
+            ? "Toleranz " + tolerance.toFixed(2) + " m überschritten."
+            : "Innerhalb der Toleranz von " + tolerance.toFixed(2) + " m.");
 
-print("\n=== Validation Complete ===");
-print("Total validations: " + validationCount);
-
-if (validationCount > 0) {
-    var finalLabels = SLabel.All();
-    var summaryMessage =
-        "Validation Session Complete\n" +
-        "Validierungssitzung abgeschlossen\n\n" +
-        "Points validated / Punkte validiert: " + validationCount + "\n" +
-        "Labels created / Labels erstellt: " + finalLabels.length + "\n" +
-        "Warning threshold / Warngrenze: " + WARNING_THRESHOLD + "m\n\n" +
-        "Label Codes / Label-Codes:\n" +
-        "1 = Local height / Lokale Höhe\n" +
-        "2 = Swisstopo reference / Referenz\n" +
-        "3 = Difference / Differenz\n" +
-        (SHOW_COORDINATES ? "4 = Easting / Ostwert\n5 = Northing / Nordwert\n" : "") +
-        "\nData source: © swisstopo\n" +
-        "Coordinate system: LV95 (EPSG:2056)";
-
-    SDialog.Message(summaryMessage, SDialog.EMessageSeverity.Info, "Session Complete");
-} else {
     SDialog.Message(
-        "No validations performed\nKeine Validierungen durchgeführt",
-        SDialog.EMessageSeverity.Warning,
-        "Session Empty"
+        message,
+        exceeded ? SDialog.EMessageSeverity.Warning : SDialog.EMessageSeverity.Success,
+        "Validation point / Validierung Punkt #" + index
     );
 }
 
-print("\n© swisstopo - Height data from api3.geo.admin.ch");
-print("=== Session End ===");
+function createSession() {
+    return {
+        total: 0,
+        ok: 0,
+        exceeded: 0,
+        apiFailed: 0,
+        sumDeviation: 0,
+        maxAbsDeviation: 0,
+        recordDeviation: function (deviation, tolerance) {
+            if (Math.abs(deviation) > tolerance) {
+                this.exceeded++;
+            } else {
+                this.ok++;
+            }
+            this.sumDeviation += deviation;
+            this.maxAbsDeviation = Math.max(this.maxAbsDeviation, Math.abs(deviation));
+        }
+    };
+}
+
+function runValidationLoop(params) {
+    print("=== " + SCRIPT_TITLE + " started (ESC stops) ===");
+    var session = createSession();
+
+    while (true) {
+        var click = SPoint.FromClick();
+        if (click.ErrorCode === 2) {
+            break; // ESC pressed
+        }
+        if (click.ErrorCode !== 0) {
+            continue; // nothing hit, keep waiting
+        }
+        validatePoint(click.Point, params, session);
+    }
+    return session;
+}
+
+function showSessionSummary(session, tolerance) {
+    var validCount = session.ok + session.exceeded;
+    var meanText = validCount > 0
+        ? (session.sumDeviation / validCount).toFixed(HEIGHT_DECIMALS) + " m"
+        : "n/a";
+
+    print("=== Validation finished: " + session.total + " point(s) ===");
+    SDialog.Message(
+        "EN: Validation complete.\n\n" +
+        "Points checked: " + session.total + "\n" +
+        "OK: " + session.ok + "\n" +
+        "Over tolerance: " + session.exceeded + "\n" +
+        "API failures: " + session.apiFailed + "\n\n" +
+        "Mean deviation: " + meanText + "\n" +
+        "Max |deviation|: " + session.maxAbsDeviation.toFixed(HEIGHT_DECIMALS) + " m\n" +
+        "Tolerance: " + tolerance.toFixed(2) + " m\n\n" +
+        "DE: Validierung abgeschlossen.\n\n" +
+        "Geprüfte Punkte: " + session.total + "\n" +
+        "OK: " + session.ok + "\n" +
+        "Über Toleranz: " + session.exceeded + "\n" +
+        "API-Fehler: " + session.apiFailed + "\n\n" +
+        "Mittlere Abweichung: " + meanText + "\n" +
+        "Max. |Abweichung|: " + session.maxAbsDeviation.toFixed(HEIGHT_DECIMALS) + " m\n" +
+        "Toleranz: " + tolerance.toFixed(2) + " m\n\n" +
+        "Data source / Datenquelle: (c) swisstopo (LV95 / EPSG:2056)",
+        session.exceeded > 0 ? SDialog.EMessageSeverity.Warning : SDialog.EMessageSeverity.Info,
+        SCRIPT_TITLE
+    );
+}
+
+/**
+ * The engine sometimes throws strings or objects without a message property;
+ * a plain error.message then reads "undefined". Always produce readable text.
+ */
+function formatError(error) {
+    if (error === null || error === undefined) {
+        return "EN: Unknown exception without an error message (engine error).\n" +
+            "DE: Unbekannte Ausnahme ohne Fehlermeldung (Engine-Fehler).";
+    }
+    if (typeof error === "string") {
+        return error;
+    }
+    if (typeof error.message === "string" && error.message.length > 0) {
+        return error.message;
+    }
+    try {
+        return "Unexpected error object / Unerwartetes Fehlerobjekt: " + JSON.stringify(error);
+    } catch (stringifyError) {
+        return "Unexpected error object / Unerwartetes Fehlerobjekt: " + String(error);
+    }
+}
+
+function handleError(error) {
+    var text = formatError(error);
+    print("ERROR: " + text);
+    if (error && typeof error.stack === "string") {
+        print("Stack:\n" + error.stack);
+    }
+    SDialog.Message(text, SDialog.EMessageSeverity.Error, SCRIPT_TITLE);
+}
+
+// ==================== Entry Point ====================
+
+main();


### PR DESCRIPTION
## Summary

Update to the two Swisstopo scripts submitted earlier (`Swisstopo validation`, `Swisstopo systematic validation`), based on production use since the original submission.

**Systematic (grid) validation - correctness fix:** the previous version centred its point-cloud search cylinder on the value returned by the swisstopo height API, before it knew the cloud's actual local height. A real elevation defect larger than roughly the cylinder's half-height (2.5 m) made the cylinder miss the point-cloud data entirely, so the affected grid cell was reported as `NO_DATA` instead of `FAILED`. The cloud's local height is now measured first, with a search cylinder spanning the full local vertical extent of the data, closing that blind spot.

**Both scripts - transport:** all HTTP calls go through a `curl` subprocess rather than the script engine's `fetch()` API. Update 2026-09-13: the intermittent SSL certificate-chain error originally seen with `fetch()` in the GUI process was the second-run-per-session issue fixed in Cyclone 3DR 2026.1.4 (verified on the nightly: 8 script runs in one GUI session, 33/33 requests OK). The curl transport stays on purpose: `fetch()` cannot be given a timeout and the engine applies none of its own (a server that accepts the connection and then stays silent keeps `fetch()` pending indefinitely, measured on 2026.1.4; only an unreachable host fails, after about 42 s via the OS connect timeout), whereas curl gets a 30 s per-request timeout. It also keeps both scripts running on Cyclone 3DR 2025.1+, with no dependency on the 2026.1.2 `fetch()` runtime.

**Both scripts - workflow and reliability:**
- Interactive validation no longer interrupts with a "continue?" dialog after every click; it keeps validating until Esc and reports a session summary (checked / OK / over tolerance / API failures, mean and max deviation) at the end.
- Systematic validation resolves reference heights in batches (`curl --parallel`, up to 40 points per call) instead of one process per grid point, with an automatic single-request retry pass for anything still missing, and an API failure diagnosis (transfer vs. response errors) in the summary if failures remain.
- Both scripts validate the LV95 position up front with a clear message, and format every error (including non-`Error` exceptions the engine can throw) into readable text instead of ever showing a blank message.
- Dialogs, tooltips and messages are English / German, matching the original submission's convention. Internal classification codes (`OK`/`FAILED`/`NO_DATA`/`API_FAILED`) and the CSV column headers are English, matching the original English-language precedent.

## Test plan

- [x] Both scripts type-check against the project's `Reshaper.d.ts` (`tsc --checkJs`)
- [x] End-to-end headless run (`3DR.exe --Silent`) of the systematic validation against the live `api3.geo.admin.ch` API: 99/99 reference heights resolved across 3 batches, 0 failures, correct `OK`/`FAILED`/`NO_DATA` classification
- [x] Manual review against the current `COMMUNITY SCRIPTS` contribution guidelines (README structure, licensing statement, tested-version note)

## Notes for reviewers

- Filenames and folder names are unchanged so existing links (including an upcoming social post referencing these two folders) keep working.
- The `/// <reference path=...>` in both scripts points at the standard `C:/Program Files/...` install path.
- Existing screenshots in `Swisstopo validation/` were left as-is; they still show a valid state since the per-point popup remains available as an opt-in setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
